### PR TITLE
Render VisualisationResult in notebooks

### DIFF
--- a/tests/test_visualisation_result.py
+++ b/tests/test_visualisation_result.py
@@ -5,7 +5,7 @@ from portus.core.visualizer import VisualisationResult
 
 def test_visualisation_result_get_plot_html_with_no_plot() -> None:
     result = VisualisationResult(text="Test", meta={}, plot=None, code=None)
-    assert result._repr_html_() is None
+    assert result._repr_mimebundle_() is None
 
 
 def test_visualisation_result_get_plot_html_with_invalid_plot() -> None:
@@ -13,7 +13,7 @@ def test_visualisation_result_get_plot_html_with_invalid_plot() -> None:
         pass
 
     result = VisualisationResult(text="Test", meta={}, plot=InvalidPlot(), code=None)
-    assert result._repr_html_() is None
+    assert result._repr_mimebundle_() is None
 
 
 def test_visualisation_result_altair() -> None:
@@ -36,7 +36,7 @@ def test_visualisation_result_altair() -> None:
     )
 
     result = VisualisationResult(text="Test representation", meta={}, plot=chart, code=None)
-    assert result._repr_html_() is not None
+    assert result._repr_mimebundle_() is not None
 
 
 @pytest.mark.xfail(reason="matplotlib does not support _repr_*_ methods")
@@ -50,4 +50,4 @@ def test_visualisation_result_matplotlib() -> None:
     ax.set_ylabel("Y axis")
     ax.set_xlabel("X axis")
     result = VisualisationResult(text="Test representation", meta={}, plot=fig, code=None)
-    assert result._repr_html_() is not None
+    assert result._repr_mimebundle_() is not None


### PR DESCRIPTION
Add `_repr_mimebundle_` to `VisualisatonResult` to render plots automatically in notebooks without having to `plot.plot`. Should work seamlessly with altair (Vega-Lite), while matplotlib does some magic I am not sure how to handle.

If `plot.plot` is None or can't be rendered, we fall back to the default `repr()` of `VisualisationResult`.

Closes #27 