### PR TITLE
Enable pretty_sql when streaming

### DIFF
--- a/databao/agents/frontend/text_frontend.py
+++ b/databao/agents/frontend/text_frontend.py
@@ -17,7 +17,7 @@ class TextStreamFrontend:
         writer: TextIO | None = None,
         escape_markdown: bool = False,
         show_headers: bool = True,
-        pretty_sql: bool = False,
+        pretty_sql: bool = True,
     ):
         self._writer = writer  # Use io.Writer type in Python 3.14
         self._escape_markdown = escape_markdown


### PR DESCRIPTION
Enable pretty printing of SQL tool calls when streaming.

```
{"sql":"SELECT ns.director, COUNT(*) AS cancelled_count\nFROM temp.main.df1 AS df\nJOIN db1.public.netflix_shows AS ns ON df.show_id = ns.show_id\nWHERE df.cancelled = TRUE\nGROUP BY ns.director\nORDER BY cancelled_count DESC;"}
```

```sql
SELECT ns.director, COUNT(*) AS cancelled_count
FROM temp.main.df1 AS df
JOIN db1.public.netflix_shows AS ns ON df.show_id = ns.show_id
WHERE df.cancelled = TRUE
GROUP BY ns.director
ORDER BY cancelled_count DESC;
```