### PR TITLE
Handle invalid Vega-Lite specs that are still drawable

### DIFF
--- a/databao/core/visualizer.py
+++ b/databao/core/visualizer.py
@@ -38,9 +38,19 @@ class VisualisationResult(BaseModel):
         if hasattr(self.plot, "_repr_mimebundle_"):
             return self.plot._repr_mimebundle_(include, exclude)
 
-        plot_html = self._get_plot_html()
-        if plot_html is not None:
-            return {"text/html": plot_html}
+        mimebundle = {}
+        if (plot_html := self._get_plot_html()) is not None:
+            mimebundle["text/html"] = plot_html
+
+        # TODO Handle all _repr_*_ methods
+        # These are mostly for fallback representations
+        if hasattr(self.plot, "_repr_png_"):
+            mimebundle["image/png"] = self.plot._repr_png_()
+        if hasattr(self.plot, "_repr_jpeg_"):
+            mimebundle["image/jpeg"] = self.plot._repr_jpeg_()
+
+        if len(mimebundle) > 0:
+            return mimebundle
         return None
 
     def _get_plot_html(self) -> str | None:


### PR DESCRIPTION
Fixes #73 

The problem was when trying to show the plot with altair which expects 100% valid Vega-Lite specs even though invalid ones can often still be rendered (which we allow since LLMs can make mistakes). Now we fallback to trying to show a static image if possible instead of crashing.