### PR TITLE
Remove pinned uv version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,6 @@ select = [
 ban-relative-imports = "all"
 
 [tool.uv]
-required-version = "==0.9.5"
-
 # https://github.com/ninoseki/uv-dynamic-versioning/blob/main/docs/tips.md#build-caching-and-editable-installs
 cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true, tags = true }}]
 


### PR DESCRIPTION
The uv version is still pinned for GH Actions files.