### PR TITLE
Remove the "default" prefix from the top level api parameters

### DIFF
--- a/databao/api.py
+++ b/databao/api.py
@@ -11,11 +11,11 @@ def new_agent(
     data_executor: Executor | None = None,
     visualizer: Visualizer | None = None,
     cache: Cache | None = None,
-    default_rows_limit: int = 1000,
-    default_stream_ask: bool = True,
-    default_stream_plot: bool = False,
-    default_lazy_threads: bool = False,
-    default_auto_output_modality: bool = True,
+    rows_limit: int = 1000,
+    stream_ask: bool = True,
+    stream_plot: bool = False,
+    lazy_threads: bool = False,
+    auto_output_modality: bool = True,
 ) -> Agent:
     """This is an entry point for users to create a new agent.
     Agent can't be modified after it's created. Only new data sources can be added.
@@ -27,9 +27,9 @@ def new_agent(
         data_executor=data_executor or LighthouseExecutor(),
         visualizer=visualizer or VegaChatVisualizer(llm_config),
         cache=cache or InMemCache(),
-        default_rows_limit=default_rows_limit,
-        default_stream_ask=default_stream_ask,
-        default_stream_plot=default_stream_plot,
-        default_lazy_threads=default_lazy_threads,
-        default_auto_output_modality=default_auto_output_modality,
+        rows_limit=rows_limit,
+        stream_ask=stream_ask,
+        stream_plot=stream_plot,
+        lazy_threads=lazy_threads,
+        auto_output_modality=auto_output_modality,
     )

--- a/databao/core/agent.py
+++ b/databao/core/agent.py
@@ -29,11 +29,11 @@ class Agent:
         cache: "Cache",
         *,
         name: str = "default_agent",
-        default_rows_limit: int,
-        default_stream_ask: bool = True,
-        default_stream_plot: bool = False,
-        default_lazy_threads: bool = False,
-        default_auto_output_modality: bool = True,
+        rows_limit: int,
+        stream_ask: bool = True,
+        stream_plot: bool = False,
+        lazy_threads: bool = False,
+        auto_output_modality: bool = True,
     ):
         self.__name = name
         self.__llm = llm.chat_model
@@ -51,11 +51,11 @@ class Agent:
         self.__cache = cache
 
         # Pipe/thread defaults
-        self.__default_rows_limit = default_rows_limit
-        self.__default_lazy_threads = default_lazy_threads
-        self.__default_auto_output_modality = default_auto_output_modality
-        self.__default_stream_ask = default_stream_ask
-        self.__default_stream_plot = default_stream_plot
+        self.__rows_limit = rows_limit
+        self.__lazy_threads = lazy_threads
+        self.__auto_output_modality = auto_output_modality
+        self.__stream_ask = stream_ask
+        self.__stream_plot = stream_plot
 
     def _parse_context_arg(self, context: str | Path | None) -> str | None:
         if context is None:
@@ -140,13 +140,13 @@ class Agent:
             raise ValueError("No databases or dataframes registered in this agent.")
         return Pipe(
             self,
-            default_rows_limit=self.__default_rows_limit,
-            default_stream_ask=stream_ask if stream_ask is not None else self.__default_stream_ask,
-            default_stream_plot=stream_plot if stream_plot is not None else self.__default_stream_plot,
-            lazy=lazy if lazy is not None else self.__default_lazy_threads,
+            rows_limit=self.__rows_limit,
+            stream_ask=stream_ask if stream_ask is not None else self.__stream_ask,
+            stream_plot=stream_plot if stream_plot is not None else self.__stream_plot,
+            lazy=lazy if lazy is not None else self.__lazy_threads,
             auto_output_modality=auto_output_modality
             if auto_output_modality is not None
-            else self.__default_auto_output_modality,
+            else self.__auto_output_modality,
         )
 
     @property

--- a/databao/core/pipe.py
+++ b/databao/core/pipe.py
@@ -23,14 +23,14 @@ class Pipe:
         self,
         agent: "Agent",
         *,
-        default_rows_limit: int = 1000,
-        default_stream_ask: bool = True,
-        default_stream_plot: bool = False,
+        rows_limit: int = 1000,
+        stream_ask: bool = True,
+        stream_plot: bool = False,
         lazy: bool = False,
         auto_output_modality: bool = True,
     ):
         self._agent = agent
-        self._default_rows_limit = default_rows_limit
+        self._default_rows_limit = rows_limit
 
         self._lazy_mode = lazy
 
@@ -43,8 +43,8 @@ class Pipe:
 
         self._stream_ask: bool | None = None
         self._stream_plot: bool | None = None
-        self._default_stream_ask: bool = default_stream_ask
-        self._default_stream_plot: bool = default_stream_plot
+        self._default_stream_ask: bool = stream_ask
+        self._default_stream_plot: bool = stream_plot
 
         self._data_materialized_rows: int | None = None
         self._data_result: ExecutionResult | None = None


### PR DESCRIPTION
I think it's more convenient to type `lazy_threads` than `default_lazy_threads` at the top level API. WDYT?