### PR TITLE
Remove @cached_property from LLMConfig.chat_model

### DIFF
--- a/databao/configs/llm.py
+++ b/databao/configs/llm.py
@@ -1,5 +1,4 @@
 import os
-from functools import cached_property
 from pathlib import Path
 from typing import Any, Literal
 
@@ -58,8 +57,7 @@ class LLMConfig(BaseModel):
         else:
             return self.timeout
 
-    @cached_property
-    def chat_model(self) -> BaseChatModel:
+    def new_chat_model(self) -> BaseChatModel:
         """Create a chat model from this config using init_chat_model for provider detection."""
         provider, name = _parse_model_provider(self.name)
         if provider == "openai" or self.api_base_url is not None:

--- a/databao/core/agent.py
+++ b/databao/core/agent.py
@@ -36,7 +36,7 @@ class Agent:
         auto_output_modality: bool = True,
     ):
         self.__name = name
-        self.__llm = llm.chat_model
+        self.__llm = llm.new_chat_model()
         self.__llm_config = llm
 
         self.__dbs: dict[str, Any] = {}

--- a/databao/executors/lighthouse/graph.py
+++ b/databao/executors/lighthouse/graph.py
@@ -154,7 +154,7 @@ class ExecuteSubmit:
 
     def compile(self, model_config: LLMConfig) -> CompiledStateGraph[Any]:
         tools = self.make_tools()
-        llm_model = model_config.chat_model
+        llm_model = model_config.new_chat_model()
 
         model_with_tools = self._model_bind_tools(llm_model, tools)
 
@@ -306,7 +306,7 @@ class ExecuteSubmit:
         model: Runnable[list[BaseMessage], Any] | None = None,
     ) -> list[BaseMessage]:
         if model is None:
-            model = config.chat_model
+            model = config.new_chat_model()
         messages = ExecuteSubmit._apply_system_prompt_caching(config, messages)
         response: AIMessage = ExecuteSubmit._call_model(model, messages)
         return [*messages, response]

--- a/databao/executors/react_duckdb/executor.py
+++ b/databao/executors/react_duckdb/executor.py
@@ -27,7 +27,7 @@ class ReactDuckDBExecutor(GraphExecutor):
 
     def _create_graph(self, data_connection: Any, llm_config: LLMConfig) -> CompiledStateGraph[Any]:
         """Create and compile the ReAct DuckDB agent graph."""
-        return make_react_duckdb_agent(data_connection, llm_config.chat_model)
+        return make_react_duckdb_agent(data_connection, llm_config.new_chat_model())
 
     def register_db(self, name: str, connection: Any) -> None:
         """Register DB in the DuckDB connection."""

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -19,7 +19,7 @@ def _validate_llm_config(config: LLMConfig) -> None:
         config.model_kwargs["validate_model_on_init"] = False
 
     try:
-        assert isinstance(config.chat_model, BaseChatModel)
+        assert isinstance(config.new_chat_model(), BaseChatModel)
     except ConnectionError as e:
         if "ollama" in str(e):
             # ollama needs to be running locally


### PR DESCRIPTION
Found the root cause of failing tests in 64dba315. The problem was that `LLMConfig.chat_model` was returning the cached LLM from whatever was the first test because the cache is global across all tests.