### PR TITLE
Add multimodal-jupyter app with Jupyter widget integration

### DIFF
--- a/client/apps/multimodal-jupyter/eslint.config.mjs
+++ b/client/apps/multimodal-jupyter/eslint.config.mjs
@@ -1,0 +1,12 @@
+import tseslint from "typescript-eslint";
+import baseConfig from "../eslint.config.mjs";
+
+export default tseslint.config(...baseConfig, {
+  files: ["src/**/*.{ts,tsx}"],
+  languageOptions: {
+    parserOptions: {
+      project: ["./tsconfig.json"],
+      tsconfigRootDir: import.meta.dirname,
+    },
+  },
+});

--- a/client/apps/multimodal-jupyter/index.html
+++ b/client/apps/multimodal-jupyter/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Databao Chart</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/apps/multimodal-jupyter/index.html
+++ b/client/apps/multimodal-jupyter/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Databao Chart</title>
+    <title>Databao multimodal viewer</title>
   </head>
   <body>
     <div id="root"></div>

--- a/client/apps/multimodal-jupyter/package.json
+++ b/client/apps/multimodal-jupyter/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@databao/multimodal-jupyter",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "nx build:pckg @databao/multimodal-jupyter",
+    "build:pckg": "tsc && NODE_ENV=production vite build"
+  },
+  "dependencies": {
+    "@anywidget/react": "0.2.0",
+    "@databao/multimodal-tabs": "workspace:*",
+    "@radix-ui/themes": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@anywidget/types": "0.2.0",
+    "@anywidget/vite": "0.2.2",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "@vitejs/plugin-react": "catalog:",
+    "vite": "catalog:",
+    "vite-plugin-checker": "catalog:",
+    "vite-plugin-lib-inject-css": "catalog:"
+  }
+}

--- a/client/apps/multimodal-jupyter/project.json
+++ b/client/apps/multimodal-jupyter/project.json
@@ -1,0 +1,4 @@
+{
+  "name": "@databao/multimodal-jupyter",
+  "root": "apps/multimodal-jupyter"
+}

--- a/client/apps/multimodal-jupyter/src/App.tsx
+++ b/client/apps/multimodal-jupyter/src/App.tsx
@@ -1,0 +1,121 @@
+import { useModel, useModelState } from "@anywidget/react";
+import { DataframeTable, Tabs, VegaChart } from "@databao/multimodal-tabs";
+import { Text, Theme } from "@radix-ui/themes";
+import { useCallback, useEffect, useRef } from "react";
+
+import styles from "./app.module.css";
+import { SelectModalityAction } from "./communication/actions";
+import { initCommunication } from "./communication/communication";
+import { StatusRenderer } from "./components/StatusRenderer";
+import {
+  isMultimodalTabType,
+  MULTIMODAL_TABS,
+  MultimodalTabType,
+  Status,
+} from "./types";
+
+function App() {
+  const model = useModel();
+  const communication = useRef(initCommunication(model));
+
+  const [availableTabs] = useModelState<MultimodalTabType[]>(
+    "available_modalities",
+  );
+
+  const [spec] = useModelState<Record<string, unknown> | null>("spec");
+  const [specStatus] = useModelState<Status>("spec_status");
+
+  const [text] = useModelState<string>("text");
+  const [textStatus] = useModelState<Status>("text_status");
+
+  const [dataframeHtmlContent] = useModelState<string>(
+    "dataframe_html_content",
+  );
+  const [dataframeHtmlContentStatus] = useModelState<Status>(
+    "dataframe_html_content_status",
+  );
+
+  useEffect(() => {
+    const firstAvailableTab = availableTabs[0];
+    if (!firstAvailableTab) return;
+
+    communication.current.sendMessage<SelectModalityAction>(
+      "SELECT_MODALITY",
+      firstAvailableTab,
+    );
+  }, [availableTabs]);
+
+  const handleChangeTab = useCallback((tab: string) => {
+    if (!isMultimodalTabType(tab)) {
+      console.error("Unknown tab value");
+      return;
+    }
+
+    communication.current.sendMessage<SelectModalityAction>(
+      "SELECT_MODALITY",
+      tab,
+    );
+  }, []);
+
+  const renderChart = (spec: Record<string, unknown> | null) => (
+    <StatusRenderer
+      status={specStatus}
+      value={spec}
+      renderValue={(value) => <VegaChart spec={value} />}
+      failed={<Text color="gray">Failed to get data</Text>}
+      empty={<Text color="gray">No chart available</Text>}
+    />
+  );
+
+  const renderDescription = (text: string | null) => (
+    <StatusRenderer
+      status={textStatus}
+      value={text}
+      renderValue={(value) => <Text color="gray">{value}</Text>}
+      failed={<Text color="gray">Failed to get data</Text>}
+      empty={<Text color="gray">No description available</Text>}
+    />
+  );
+
+  const renderTable = (dataframeHtmlContent: string | null) => (
+    <StatusRenderer
+      status={dataframeHtmlContentStatus}
+      value={dataframeHtmlContent}
+      renderValue={(value) => <DataframeTable htmlContent={value} />}
+      failed={<Text color="gray">Failed to get data</Text>}
+      empty={<Text color="gray">No data available</Text>}
+    />
+  );
+
+  const defaultTabs = {
+    DATAFRAME: {
+      type: MULTIMODAL_TABS.DATAFRAME,
+      title: "Data",
+      content: () => renderTable(dataframeHtmlContent),
+    },
+    CHART: {
+      type: MULTIMODAL_TABS.CHART,
+      title: "Chart",
+      content: () => renderChart(spec),
+    },
+    DESCRIPTION: {
+      type: MULTIMODAL_TABS.DESCRIPTION,
+      title: "Description",
+      content: () => renderDescription(text),
+    },
+  };
+
+  const tabs = availableTabs
+    .map((tab) => defaultTabs[tab])
+    .filter((tab) => isMultimodalTabType(tab.type));
+
+  return (
+    <Theme style={{ minHeight: "300px", maxHeight: "700px" }} asChild>
+      <div className={styles.root}>
+        <Tabs tabs={tabs} onChangeTab={handleChangeTab} />
+      </div>
+    </Theme>
+  );
+}
+
+export default App;

--- a/client/apps/multimodal-jupyter/src/app.module.css
+++ b/client/apps/multimodal-jupyter/src/app.module.css
@@ -1,0 +1,3 @@
+.root {
+  display: flex;
+}

--- a/client/apps/multimodal-jupyter/src/communication/actions.ts
+++ b/client/apps/multimodal-jupyter/src/communication/actions.ts
@@ -1,0 +1,10 @@
+import { MultimodalTabType } from "@/types";
+
+export type AllActions = {
+  SELECT_MODALITY: SelectModalityAction;
+};
+
+export type SelectModalityAction = {
+  type: "SELECT_MODALITY";
+  value: MultimodalTabType;
+};

--- a/client/apps/multimodal-jupyter/src/communication/communication.ts
+++ b/client/apps/multimodal-jupyter/src/communication/communication.ts
@@ -1,0 +1,29 @@
+import { AnyModel } from "@anywidget/types";
+
+import { Action, MessageRequest } from "./types";
+
+export function initCommunication(model: AnyModel) {
+  const sendMessage = <ActionT extends Action>(
+    action: ActionT["type"],
+    payload: ActionT["value"],
+  ) => {
+    const rawMessage = createRawMessage(action, payload);
+    model.send(rawMessage);
+  };
+
+  return {
+    sendMessage,
+  };
+}
+
+function createRawMessage(
+  action: Action["type"],
+  payload: Action["value"],
+): MessageRequest {
+  return {
+    action: {
+      type: action,
+      payload: JSON.stringify(payload),
+    },
+  };
+}

--- a/client/apps/multimodal-jupyter/src/communication/types.ts
+++ b/client/apps/multimodal-jupyter/src/communication/types.ts
@@ -1,0 +1,10 @@
+import { AllActions } from "./actions";
+
+export type Action = AllActions[keyof AllActions];
+
+export type MessageRequest = {
+  action: {
+    type: Action["type"];
+    payload: string;
+  };
+};

--- a/client/apps/multimodal-jupyter/src/components/StatusRenderer.tsx
+++ b/client/apps/multimodal-jupyter/src/components/StatusRenderer.tsx
@@ -1,0 +1,43 @@
+import { Spinner, Text } from "@radix-ui/themes";
+import { ReactElement } from "react";
+
+import type { Status } from "../types";
+
+import styles from "./statusRenderer.module.css";
+
+export type StatusRendererProps<T> = {
+  status: Status;
+  value: T | null | undefined;
+  renderValue: (value: T) => ReactElement;
+  empty: ReactElement;
+  failed: ReactElement;
+  loadingText?: string;
+};
+
+export function StatusRenderer<T>({
+  status,
+  value,
+  renderValue,
+  empty,
+  failed,
+  loadingText = "Generating...",
+}: StatusRendererProps<T>): ReactElement {
+  if (status === "initial" || status === "loading") {
+    return (
+      <div className={styles.loader}>
+        <Spinner />
+        <Text color="gray">{loadingText}</Text>
+      </div>
+    );
+  }
+
+  if (status === "failed") {
+    return failed;
+  }
+
+  if (status === "loaded" && value != null) {
+    return renderValue(value);
+  }
+
+  return empty;
+}

--- a/client/apps/multimodal-jupyter/src/components/statusRenderer.module.css
+++ b/client/apps/multimodal-jupyter/src/components/statusRenderer.module.css
@@ -1,0 +1,5 @@
+.loader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/client/apps/multimodal-jupyter/src/main.tsx
+++ b/client/apps/multimodal-jupyter/src/main.tsx
@@ -1,0 +1,11 @@
+import type { AnyWidget } from "@anywidget/types";
+
+import { createRender } from "@anywidget/react";
+
+import App from "./App";
+
+import "./styles/main.css";
+
+const widget: AnyWidget = { render: createRender(App) };
+
+export default widget;

--- a/client/apps/multimodal-jupyter/src/styles/main.css
+++ b/client/apps/multimodal-jupyter/src/styles/main.css
@@ -1,0 +1,1 @@
+@import "@radix-ui/themes/styles.css";

--- a/client/apps/multimodal-jupyter/src/types.ts
+++ b/client/apps/multimodal-jupyter/src/types.ts
@@ -1,0 +1,12 @@
+export const MULTIMODAL_TABS = {
+  CHART: "CHART",
+  DESCRIPTION: "DESCRIPTION",
+  DATAFRAME: "DATAFRAME",
+} as const;
+
+export type MultimodalTabType = keyof typeof MULTIMODAL_TABS;
+export type Status = "initial" | "loading" | "loaded" | "failed";
+
+export function isMultimodalTabType(tab: string): tab is MultimodalTabType {
+  return tab in MULTIMODAL_TABS;
+}

--- a/client/apps/multimodal-jupyter/src/vite-env.d.ts
+++ b/client/apps/multimodal-jupyter/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/client/apps/multimodal-jupyter/tsconfig.json
+++ b/client/apps/multimodal-jupyter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+    },
+    "noEmit": true,
+    "declaration": false,
+    "composite": false,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+  },
+  "include": ["src", "vite.config.ts"],
+  "exclude": ["node_modules"],
+}

--- a/client/apps/multimodal-jupyter/vite.config.ts
+++ b/client/apps/multimodal-jupyter/vite.config.ts
@@ -1,0 +1,41 @@
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { defineConfig } from "vite";
+import { checker } from "vite-plugin-checker";
+
+import { dynamicTSConfig } from "../../vite.config.mts";
+
+export default defineConfig({
+  plugins: [
+    react(),
+    checker({
+      typescript: {
+        tsconfigPath: dynamicTSConfig(),
+      },
+    }),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  define: {
+    "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+  },
+  build: {
+    outDir: "../../out/multimodal-jupyter",
+    emptyOutDir: true,
+    lib: {
+      entry: path.resolve(__dirname, "src/main.tsx"),
+      formats: ["es"],
+      fileName: () => "index.js",
+    },
+    cssCodeSplit: false,
+    rollupOptions: {
+      external: [],
+      output: {
+        assetFileNames: "style.css",
+      },
+    },
+  },
+});

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -130,6 +130,52 @@ importers:
         specifier: 2.0.2
         version: 2.0.2(rollup@4.57.1)(vite@6.0.5(@types/node@25.0.3)(terser@5.46.0)(yaml@2.8.2))
 
+  apps/multimodal-jupyter:
+    dependencies:
+      '@anywidget/react':
+        specifier: 0.2.0
+        version: 0.2.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@databao/multimodal-tabs':
+        specifier: workspace:*
+        version: link:../../packages/multimodal-tabs
+      '@radix-ui/themes':
+        specifier: 'catalog:'
+        version: 3.2.1(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: 'catalog:'
+        version: 18.3.1
+      react-dom:
+        specifier: 'catalog:'
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@anywidget/types':
+        specifier: 0.2.0
+        version: 0.2.0
+      '@anywidget/vite':
+        specifier: 0.2.2
+        version: 0.2.2(vite@6.0.5(@types/node@25.0.3)(terser@5.46.0)(yaml@2.8.2))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.0.3
+      '@types/react':
+        specifier: 'catalog:'
+        version: 18.3.12
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 18.3.1
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 4.3.4(vite@6.0.5(@types/node@25.0.3)(terser@5.46.0)(yaml@2.8.2))
+      vite:
+        specifier: 'catalog:'
+        version: 6.0.5(@types/node@25.0.3)(terser@5.46.0)(yaml@2.8.2)
+      vite-plugin-checker:
+        specifier: 'catalog:'
+        version: 0.12.0(eslint@9.31.0)(optionator@0.9.4)(typescript@5.8.3)(vite@6.0.5(@types/node@25.0.3)(terser@5.46.0)(yaml@2.8.2))
+      vite-plugin-lib-inject-css:
+        specifier: 'catalog:'
+        version: 2.2.2(vite@6.0.5(@types/node@25.0.3)(terser@5.46.0)(yaml@2.8.2))
+
   packages/multimodal-tabs:
     dependencies:
       '@radix-ui/themes':
@@ -177,6 +223,22 @@ importers:
         version: 2.2.2(vite@6.0.5(@types/node@25.0.3)(terser@5.46.0)(yaml@2.8.2))
 
 packages:
+
+  '@anywidget/react@0.2.0':
+    resolution: {integrity: sha512-7jmyfEeKDzMAOmdvzQ/KNtct72lqR1j6KYtb3RtrnHoDMMO5aymqbXib5bvDdnZQOiqlTU+B+cKxtBpYc0W4hg==}
+    peerDependencies:
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@anywidget/types@0.2.0':
+    resolution: {integrity: sha512-+XtK4uwxRd4JpuevUMhirrbvC0V4yCA/i0lEjhmSAtOaxiXIg/vBKzaSonDuoZ1a9LEjUXTW2+m7w+ULgsJYvg==}
+
+  '@anywidget/vite@0.2.2':
+    resolution: {integrity: sha512-6qYispivu+VAvWJbWSsZujGAQXLW5Xve/cNA/zrz+RXeg31xfJ5bH5ylqp6UC+GpFZL8azRN6HQS24Z0IgURLw==}
+    peerDependencies:
+      vite: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@ast-grep/napi-darwin-arm64@0.36.3':
     resolution: {integrity: sha512-uM0Hrm5gcHqaBL64ktmPBFMTorTlPKWsUfi0E2Cg09GJfeYWvZmicCqgd7qVtjURmQvFQdb4JSqHIkJvws6Uqw==}
@@ -4631,6 +4693,20 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@anywidget/react@0.2.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@anywidget/types': 0.2.0
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@anywidget/types@0.2.0': {}
+
+  '@anywidget/vite@0.2.2(vite@6.0.5(@types/node@25.0.3)(terser@5.46.0)(yaml@2.8.2))':
+    dependencies:
+      vite: 6.0.5(@types/node@25.0.3)(terser@5.46.0)(yaml@2.8.2)
 
   '@ast-grep/napi-darwin-arm64@0.36.3':
     optional: true

--- a/databao/core/env.py
+++ b/databao/core/env.py
@@ -1,0 +1,22 @@
+def in_jupyter_kernel() -> bool:
+    """
+    Return True when running inside a Jupyter/IPython kernel (ipykernel).
+
+    Notes:
+    - This is typically True in Jupyter Notebook, JupyterLab, VS Code notebooks, Google Colab.
+    - This is typically False in regular Python scripts and in terminal IPython.
+    - The check is best-effort: if IPython isn't available or behaves unexpectedly,
+      this returns False.
+    """
+    try:
+        # IPython doesn't provide type stubs, so we need to ignore type checking here
+        from IPython.core.getipython import get_ipython
+
+        ip = get_ipython()  # type: ignore[no-untyped-call]
+        if ip is None:
+            return False
+
+        # In ipykernel, the config usually contains this key.
+        return "IPKernelApp" in getattr(ip, "config", {})
+    except Exception:
+        return False

--- a/databao/core/thread.py
+++ b/databao/core/thread.py
@@ -4,12 +4,15 @@ from typing import TYPE_CHECKING, Any, Self, TextIO
 
 from pandas import DataFrame
 
+from databao.core.env import in_jupyter_kernel
 from databao.core.executor import ExecutionResult, OutputModalityHints
 from databao.core.opa import Opa
 from databao.core.visualizer import VisualisationResult
 
 if TYPE_CHECKING:
     from databao.core.agent import Agent
+    from databao.core.visualizer import VisualisationResult
+    from databao.multimodal.jupyter_widget import MultimodalWidget
 
 
 class Thread:
@@ -166,18 +169,25 @@ class Thread:
         self._stream_plot = stream
         return self._materialize_visualization(request, rows_limit if rows_limit else self._data_materialized_rows)
 
-    def html(self) -> str:
-        """Generate HTML and open it in the browser.
+    def html(self) -> "str | MultimodalWidget":
+        """Render the thread as HTML.
 
-        This method creates a standalone HTML file with the Vega-Lite chart, dataframe, and text
-        and opens it in the default web browser.
+        Behavior:
+        - In Jupyter notebooks (IPython kernel): return a `MultimodalWidget` so it renders in the output cell.
+        - In terminal / scripts: generate standalone HTML and open it in the default web browser.
 
         Returns:
-            The URL that was opened in the browser.
+            - `MultimodalWidget` in Jupyter
+            - The URL that was opened in the browser otherwise
 
         Raises:
             ValueError: If visualization generation fails.
         """
+        if in_jupyter_kernel():
+            from databao.multimodal import create_jupyter_widget
+
+            return create_jupyter_widget(self)
+
         from databao.multimodal import open_html_content
 
         return open_html_content(self)

--- a/databao/multimodal/__init__.py
+++ b/databao/multimodal/__init__.py
@@ -1,10 +1,16 @@
 """Databao viewer module for displaying multimodal tabs in the browser."""
 
 from databao.multimodal.html_viewer import open_html_content
-from databao.multimodal.jupyter_widget import MultimodalWidget, create_jupyter_widget
 
-__all__ = [
-    "MultimodalWidget",
-    "create_jupyter_widget",
-    "open_html_content",
-]
+try:
+    from databao.multimodal.jupyter_widget import MultimodalWidget, create_jupyter_widget
+
+    __all__ = [
+        "MultimodalWidget",
+        "create_jupyter_widget",
+        "open_html_content",
+    ]
+except ImportError:
+    __all__ = [
+        "open_html_content",
+    ]

--- a/databao/multimodal/__init__.py
+++ b/databao/multimodal/__init__.py
@@ -1,7 +1,10 @@
 """Databao viewer module for displaying multimodal tabs in the browser."""
 
 from databao.multimodal.html_viewer import open_html_content
+from databao.multimodal.jupyter_widget import MultimodalWidget, create_jupyter_widget
 
 __all__ = [
+    "MultimodalWidget",
+    "create_jupyter_widget",
     "open_html_content",
 ]

--- a/databao/multimodal/html_viewer.py
+++ b/databao/multimodal/html_viewer.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 from edaplot.data_utils import spec_add_data
 
+from databao.multimodal.utils import dataframe_to_html
 from databao.visualizers.vega_chat import VegaChatResult
 
 if TYPE_CHECKING:
@@ -185,24 +186,6 @@ class MultimodalHTTPRequestHandler(BaseHTTPRequestHandler):
         return
 
 
-def _dataframe_to_html(df: "Any") -> str:
-    import pandas as pd
-
-    if len(df) > 20:
-        first_10 = df.head(10)
-        last_10 = df.tail(10)
-
-        separator_data = {col: "..." for col in df.columns}
-        separator_df = pd.DataFrame([separator_data], index=["..."])
-
-        truncated_df = pd.concat([first_10, separator_df, last_10])
-        html_result = truncated_df.to_html()
-    else:
-        html_result = df.to_html()
-
-    return html_result if html_result is not None else ""
-
-
 def open_html_content(thread: "Thread") -> str:
     """Create an HTML file with the embedded Vega spec and open it in the browser.
 
@@ -227,7 +210,7 @@ def open_html_content(thread: "Thread") -> str:
         )
 
     df = thread.df()
-    df_html = _dataframe_to_html(df) if df is not None else "<i>No data available</i>"
+    df_html = dataframe_to_html(df) if df is not None else "<i>No data available</i>"
 
     data_object = {"text": thread.text(), "dataframeHtmlContent": df_html}
     data_json = json.dumps(data_object)

--- a/databao/multimodal/jupyter_widget.py
+++ b/databao/multimodal/jupyter_widget.py
@@ -1,6 +1,7 @@
 """Widget module for displaying multimodal content in Jupyter notebooks."""
 
 import json
+import logging
 from collections.abc import Callable
 from enum import Enum
 from pathlib import Path
@@ -16,6 +17,8 @@ from databao.visualizers.vega_chat import VegaChatResult
 if TYPE_CHECKING:
     from databao.core.thread import Thread
 
+logger = logging.getLogger(__name__)
+
 
 WIDGET_ESM_PATH = Path(__file__).parent.parent.parent / "client" / "out" / "multimodal-jupyter" / "index.js"
 WIDGET_CSS_PATH = Path(__file__).parent.parent.parent / "client" / "out" / "multimodal-jupyter" / "style.css"
@@ -30,8 +33,6 @@ class MultimodalWidget(anywidget.AnyWidget):
 
     _esm = WIDGET_ESM_PATH
     _css = WIDGET_CSS_PATH if WIDGET_CSS_PATH.exists() else None
-
-    thread: "Thread"
 
     available_modalities = traitlets.List(["DATAFRAME", "DESCRIPTION", "CHART"]).tag(sync=True)
 
@@ -109,7 +110,7 @@ class MultimodalWidget(anywidget.AnyWidget):
 
             if df is None:
                 self.dataframe_html_content_status = "failed"
-                raise ValueError("Failed to generate data")
+                raise ValueError("Failed to generate dataframe")
 
             self.dataframe_html_content_status = "loaded"
             self.dataframe_html_content = dataframe_to_html(df)
@@ -125,20 +126,17 @@ class MultimodalWidget(anywidget.AnyWidget):
 
     def _on_client_message(
         self,
-        widget: "MultimodalWidget",
+        _widget: "MultimodalWidget",
         content: dict[str, Any],
-        buffers: list[memoryview],
+        _buffers: list[memoryview],
     ) -> None:
-        del widget
-        self._handle_client_message(content, buffers)
+        self._handle_client_message(content, _buffers)
 
     def _handle_client_message(
         self,
         content: dict[str, Any],
-        buffers: list[memoryview],
+        _buffers: list[memoryview],
     ) -> None:
-        del buffers
-
         action = content.get("action", {})
         action_type_str = action.get("type")
 
@@ -154,9 +152,9 @@ class MultimodalWidget(anywidget.AnyWidget):
                 action_payload = json.loads(raw_payload) if isinstance(raw_payload, str) and raw_payload else {}
                 handler(action_payload)
             else:
-                raise SystemError(f"No handler for action: {action_type.value}")
-        except (ValueError, json.JSONDecodeError):
-            pass
+                raise ValueError(f"No handler for action: {action_type.value}")
+        except (ValueError, json.JSONDecodeError) as e:
+            logger.debug(f"Failed to handle client message: {e}")
 
 
 def create_jupyter_widget(

--- a/databao/multimodal/jupyter_widget.py
+++ b/databao/multimodal/jupyter_widget.py
@@ -1,0 +1,184 @@
+"""Widget module for displaying multimodal content in Jupyter notebooks."""
+
+import json
+from collections.abc import Callable
+from enum import Enum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import anywidget
+import traitlets
+from edaplot.data_utils import spec_add_data
+
+from databao.multimodal.utils import dataframe_to_html
+from databao.visualizers.vega_chat import VegaChatResult
+
+if TYPE_CHECKING:
+    from databao.core.thread import Thread
+
+
+WIDGET_ESM_PATH = Path(__file__).parent.parent.parent / "client" / "out" / "multimodal-jupyter" / "index.js"
+WIDGET_CSS_PATH = Path(__file__).parent.parent.parent / "client" / "out" / "multimodal-jupyter" / "style.css"
+
+
+class ClientAction(Enum):
+    SELECT_MODALITY = "SELECT_MODALITY"
+
+
+class MultimodalWidget(anywidget.AnyWidget):
+    """An anywidget for displaying multimodal content in Jupyter notebooks."""
+
+    _esm = WIDGET_ESM_PATH
+    _css = WIDGET_CSS_PATH if WIDGET_CSS_PATH.exists() else None
+
+    thread: "Thread"
+
+    available_modalities = traitlets.List(["DATAFRAME", "DESCRIPTION", "CHART"]).tag(sync=True)
+
+    spec = traitlets.Dict(default_value=None, allow_none=True).tag(sync=True)
+    spec_status = traitlets.Enum(values=["initial", "loading", "loaded", "failed"], default_value="initial").tag(
+        sync=True
+    )
+
+    text = traitlets.Unicode("").tag(sync=True)
+    text_status = traitlets.Enum(values=["initial", "loading", "loaded", "failed"], default_value="initial").tag(
+        sync=True
+    )
+
+    dataframe_html_content = traitlets.Unicode("").tag(sync=True)
+    dataframe_html_content_status = traitlets.Enum(
+        values=["initial", "loading", "loaded", "failed"], default_value="initial"
+    ).tag(sync=True)
+
+    def __init__(
+        self,
+        thread: "Thread",
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the multimodal widget.
+
+        Args:
+            thread: The databao thread to interact with.
+            **kwargs: Additional arguments passed to the parent class.
+        """
+        super().__init__(**kwargs)
+
+        self.thread = thread
+
+        thread_text = thread.text()
+        self.text = thread_text
+        self.text_status = "loaded"
+
+        df = thread.df()
+        if df is not None:
+            self.dataframe_html_content = dataframe_to_html(df)
+            self.dataframe_html_content_status = "loaded"
+
+        self.on_msg(self._on_client_message)
+
+        self._action_handlers: dict[ClientAction, Callable[[Any], None]] = {
+            ClientAction.SELECT_MODALITY: self._handle_change_tab,
+        }
+
+    def _handle_change_tab(self, payload: str) -> None:
+        if payload == "CHART":
+            if self.spec_status != "initial":
+                return
+
+            self.spec_status = "loading"
+            plot = self.thread.plot()
+
+            if not isinstance(plot, VegaChatResult):
+                self.spec_status = "failed"
+                raise ValueError("Failed to generate visualization")
+
+            if plot.spec is None or plot.spec_df is None:
+                self.spec_status = "failed"
+                raise ValueError("Failed to generate visualization")
+
+            spec_with_data = spec_add_data(plot.spec.copy(), plot.spec_df)
+            self.spec_status = "loaded"
+            self.spec = spec_with_data
+
+        elif payload == "DATAFRAME":
+            if self.dataframe_html_content_status != "initial":
+                return
+
+            self.dataframe_html_content_status = "loading"
+            df = self.thread.df()
+
+            if df is None:
+                self.dataframe_html_content_status = "failed"
+                raise ValueError("Failed to generate data")
+
+            self.dataframe_html_content_status = "loaded"
+            self.dataframe_html_content = dataframe_to_html(df)
+
+        elif payload == "DESCRIPTION":
+            if self.text_status != "initial":
+                return
+
+            self.text_status = "loading"
+            prepared_text = self.thread.text()
+            self.text = prepared_text
+            self.text_status = "loaded"
+
+    def _on_client_message(
+        self,
+        widget: "MultimodalWidget",
+        content: dict[str, Any],
+        buffers: list[memoryview],
+    ) -> None:
+        del widget
+        self._handle_client_message(content, buffers)
+
+    def _handle_client_message(
+        self,
+        content: dict[str, Any],
+        buffers: list[memoryview],
+    ) -> None:
+        del buffers
+
+        action = content.get("action", {})
+        action_type_str = action.get("type")
+
+        if not action_type_str:
+            return
+
+        try:
+            action_type = ClientAction(action_type_str)
+            raw_payload = action.get("payload")
+            action_payload = json.loads(raw_payload) if isinstance(raw_payload, str) and raw_payload else {}
+
+            handler = self._action_handlers.get(action_type)
+
+            if handler:
+                handler(action_payload)
+            else:
+                raise SystemError(f"No handler for action: {action_type.value}")
+        except (ValueError, json.JSONDecodeError):
+            pass
+
+
+def create_jupyter_widget(
+    thread: "Thread",
+) -> "MultimodalWidget":
+    """Create an anywidget for displaying multimodal content in Jupyter notebooks.
+
+    Args:
+        thread: The databao thread to interact with.
+
+    Returns:
+        A MultimodalWidget instance.
+
+    Raises:
+        FileNotFoundError: If the widget ESM file is not found.
+    """
+    if not WIDGET_ESM_PATH.exists():
+        raise FileNotFoundError(
+            f"Widget ESM file not found at {WIDGET_ESM_PATH}. "
+            "This usually means the frontend wasn't built during installation. "
+            "If you installed from pip, please report this as a bug."
+        )
+
+    return MultimodalWidget(thread=thread)

--- a/databao/multimodal/jupyter_widget.py
+++ b/databao/multimodal/jupyter_widget.py
@@ -26,8 +26,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-WIDGET_ESM_PATH = Path(__file__).parent.parent.parent / "client" / "out" / "multimodal-jupyter" / "index.js"
-WIDGET_CSS_PATH = Path(__file__).parent.parent.parent / "client" / "out" / "multimodal-jupyter" / "style.css"
+_PROJECT_ROOT = Path(__file__).parent.parent.parent
+_WIDGET_OUT_DIR = _PROJECT_ROOT / "client" / "out" / "multimodal-jupyter"
+
+WIDGET_ESM_PATH = _WIDGET_OUT_DIR / "index.js"
+WIDGET_CSS_PATH = _WIDGET_OUT_DIR / "style.css"
 
 LOADING_STATUS_VALUES = ("initial", "loading", "loaded", "failed")
 

--- a/databao/multimodal/jupyter_widget.py
+++ b/databao/multimodal/jupyter_widget.py
@@ -147,12 +147,11 @@ class MultimodalWidget(anywidget.AnyWidget):
 
         try:
             action_type = ClientAction(action_type_str)
-            raw_payload = action.get("payload")
-            action_payload = json.loads(raw_payload) if isinstance(raw_payload, str) and raw_payload else {}
-
             handler = self._action_handlers.get(action_type)
 
             if handler:
+                raw_payload = action.get("payload")
+                action_payload = json.loads(raw_payload) if isinstance(raw_payload, str) and raw_payload else {}
                 handler(action_payload)
             else:
                 raise SystemError(f"No handler for action: {action_type.value}")

--- a/databao/multimodal/jupyter_widget.py
+++ b/databao/multimodal/jupyter_widget.py
@@ -23,6 +23,8 @@ logger = logging.getLogger(__name__)
 WIDGET_ESM_PATH = Path(__file__).parent.parent.parent / "client" / "out" / "multimodal-jupyter" / "index.js"
 WIDGET_CSS_PATH = Path(__file__).parent.parent.parent / "client" / "out" / "multimodal-jupyter" / "style.css"
 
+LOADING_STATUS_VALUES = ("initial", "loading", "loaded", "failed")
+
 
 class ClientAction(Enum):
     SELECT_MODALITY = "SELECT_MODALITY"
@@ -37,19 +39,13 @@ class MultimodalWidget(anywidget.AnyWidget):
     available_modalities = traitlets.List(["DATAFRAME", "DESCRIPTION", "CHART"]).tag(sync=True)
 
     spec = traitlets.Dict(default_value=None, allow_none=True).tag(sync=True)
-    spec_status = traitlets.Enum(values=["initial", "loading", "loaded", "failed"], default_value="initial").tag(
-        sync=True
-    )
+    spec_status = traitlets.Enum(values=LOADING_STATUS_VALUES, default_value="initial").tag(sync=True)
 
     text = traitlets.Unicode("").tag(sync=True)
-    text_status = traitlets.Enum(values=["initial", "loading", "loaded", "failed"], default_value="initial").tag(
-        sync=True
-    )
+    text_status = traitlets.Enum(values=LOADING_STATUS_VALUES, default_value="initial").tag(sync=True)
 
     dataframe_html_content = traitlets.Unicode("").tag(sync=True)
-    dataframe_html_content_status = traitlets.Enum(
-        values=["initial", "loading", "loaded", "failed"], default_value="initial"
-    ).tag(sync=True)
+    dataframe_html_content_status = traitlets.Enum(values=LOADING_STATUS_VALUES, default_value="initial").tag(sync=True)
 
     def __init__(
         self,

--- a/databao/multimodal/jupyter_widget.py
+++ b/databao/multimodal/jupyter_widget.py
@@ -7,8 +7,14 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import anywidget
-import traitlets
+try:
+    import anywidget
+    import traitlets
+except ImportError as e:
+    raise ImportError(
+        "anywidget and traitlets are required for Jupyter notebook support. "
+        "Install them with: pip install databao[jupyter]"
+    ) from e
 from edaplot.data_utils import spec_add_data
 
 from databao.multimodal.utils import dataframe_to_html

--- a/databao/multimodal/utils.py
+++ b/databao/multimodal/utils.py
@@ -1,0 +1,29 @@
+"""Utility functions for multimodal display."""
+
+from typing import Any
+
+
+def dataframe_to_html(df: Any) -> str:
+    """Convert a DataFrame to HTML, truncating if necessary.
+
+    Args:
+        df: A pandas DataFrame to convert to HTML.
+
+    Returns:
+        HTML string representation of the DataFrame.
+    """
+    import pandas as pd
+
+    if len(df) > 20:
+        first_10 = df.head(10)
+        last_10 = df.tail(10)
+
+        separator_data = {col: "..." for col in df.columns}
+        separator_df = pd.DataFrame([separator_data], index=["..."])
+
+        truncated_df = pd.concat([first_10, separator_df, last_10])
+        html_result = truncated_df.to_html()
+    else:
+        html_result = df.to_html()
+
+    return html_result if html_result is not None else ""

--- a/databao/multimodal/utils.py
+++ b/databao/multimodal/utils.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import pandas as pd
+import pandas as pd
 
 
 def dataframe_to_html(df: pd.DataFrame) -> str:
@@ -17,8 +14,6 @@ def dataframe_to_html(df: pd.DataFrame) -> str:
     Returns:
         HTML string representation of the DataFrame.
     """
-    import pandas as pd
-
     if len(df) > 20:
         first_10 = df.head(10)
         last_10 = df.tail(10)

--- a/databao/multimodal/utils.py
+++ b/databao/multimodal/utils.py
@@ -1,9 +1,14 @@
 """Utility functions for multimodal display."""
 
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
-def dataframe_to_html(df: Any) -> str:
+def dataframe_to_html(df: pd.DataFrame) -> str:
     """Convert a DataFrame to HTML, truncating if necessary.
 
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,15 @@ Homepage = "https://databao.app/"
 Source = "https://github.com/JetBrains/databao"
 
 [project.optional-dependencies]
+jupyter = [
+    "anywidget>=0.9.0",
+    "traitlets>=5.0.0",
+]
 examples = [
     "notebook>=7.4.7",
     "python-dotenv>=1.1.1",
+    "anywidget>=0.9.0",
+    "traitlets>=5.0.0",
 ]
 
 [build-system]

--- a/tests/test_jupyter_widget.py
+++ b/tests/test_jupyter_widget.py
@@ -1,0 +1,226 @@
+"""Tests for MultimodalWidget in databao/multimodal/jupyter_widget.py."""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from databao.multimodal.jupyter_widget import MultimodalWidget
+from databao.visualizers.vega_chat import VegaChatResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_thread(
+    *,
+    text: str = "result text",
+    df: pd.DataFrame | None = None,
+    plot: Any = None,
+) -> MagicMock:
+    """Build a minimal mock Thread."""
+    thread = MagicMock()
+    thread.text.return_value = text
+    thread.df.return_value = df
+    thread.plot.return_value = plot
+    return thread
+
+
+def _make_vega_result(*, spec: dict[str, Any] | None = None, spec_df: pd.DataFrame | None = None) -> VegaChatResult:
+    return VegaChatResult(text="", meta={}, plot=None, code=None, visualizer=None, spec=spec, spec_df=spec_df)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_df() -> pd.DataFrame:
+    return pd.DataFrame({"a": range(5), "b": range(5, 10)})
+
+
+@pytest.fixture()
+def sample_spec() -> dict[str, Any]:
+    return {"mark": "point", "encoding": {"x": {"field": "a"}, "y": {"field": "b"}}}
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+
+def test_init_sets_text(sample_df: pd.DataFrame) -> None:
+    thread = _make_thread(text="hello", df=sample_df)
+    widget = MultimodalWidget(thread=thread)
+
+    assert widget.text == "hello"
+    assert widget.text_status == "loaded"
+
+
+def test_init_sets_dataframe_html_when_df_present(sample_df: pd.DataFrame) -> None:
+    thread = _make_thread(df=sample_df)
+    widget = MultimodalWidget(thread=thread)
+
+    assert widget.dataframe_html_content != ""
+    assert widget.dataframe_html_content_status == "loaded"
+
+
+def test_init_leaves_dataframe_status_initial_when_no_df() -> None:
+    thread = _make_thread(df=None)
+    widget = MultimodalWidget(thread=thread)
+
+    assert widget.dataframe_html_content == ""
+    assert widget.dataframe_html_content_status == "initial"
+
+
+def test_init_spec_status_is_initial(sample_df: pd.DataFrame) -> None:
+    thread = _make_thread(df=sample_df)
+    widget = MultimodalWidget(thread=thread)
+
+    assert widget.spec is None
+    assert widget.spec_status == "initial"
+
+
+# ---------------------------------------------------------------------------
+# SELECT_MODALITY: CHART tab
+# ---------------------------------------------------------------------------
+
+
+def test_chart_tab_loads_spec(sample_df: pd.DataFrame, sample_spec: dict[str, Any]) -> None:
+    plot = _make_vega_result(spec=sample_spec, spec_df=sample_df)
+    thread = _make_thread(df=sample_df, plot=plot)
+    widget = MultimodalWidget(thread=thread)
+
+    msg = {"action": {"type": "SELECT_MODALITY", "payload": json.dumps("CHART")}}
+    widget._handle_client_message(msg, [])
+
+    assert widget.spec_status == "loaded"
+    assert widget.spec is not None
+
+
+def test_chart_tab_idempotent_when_already_loaded(sample_df: pd.DataFrame, sample_spec: dict[str, Any]) -> None:
+    plot = _make_vega_result(spec=sample_spec, spec_df=sample_df)
+    thread = _make_thread(df=sample_df, plot=plot)
+    widget = MultimodalWidget(thread=thread)
+
+    msg = {"action": {"type": "SELECT_MODALITY", "payload": json.dumps("CHART")}}
+    widget._handle_client_message(msg, [])
+    widget._handle_client_message(msg, [])
+
+    thread.plot.assert_called_once()
+
+
+def test_chart_tab_sets_failed_status_when_plot_not_vega(sample_df: pd.DataFrame) -> None:
+    thread = _make_thread(df=sample_df, plot=MagicMock(spec=[]))  # not a VegaChatResult
+    widget = MultimodalWidget(thread=thread)
+
+    msg = {"action": {"type": "SELECT_MODALITY", "payload": json.dumps("CHART")}}
+    widget._handle_client_message(msg, [])
+
+    assert widget.spec_status == "failed"
+
+
+def test_chart_tab_sets_failed_status_when_spec_is_none(sample_df: pd.DataFrame) -> None:
+    plot = _make_vega_result(spec=None, spec_df=sample_df)
+    thread = _make_thread(df=sample_df, plot=plot)
+    widget = MultimodalWidget(thread=thread)
+
+    msg = {"action": {"type": "SELECT_MODALITY", "payload": json.dumps("CHART")}}
+    widget._handle_client_message(msg, [])
+
+    assert widget.spec_status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# SELECT_MODALITY: DATAFRAME tab
+# ---------------------------------------------------------------------------
+
+
+def test_dataframe_tab_loads_html_when_df_available(sample_df: pd.DataFrame) -> None:
+    thread = _make_thread(df=None)  # no df at init
+    widget = MultimodalWidget(thread=thread)
+    assert widget.dataframe_html_content_status == "initial"
+
+    thread.df.return_value = sample_df
+    msg = {"action": {"type": "SELECT_MODALITY", "payload": json.dumps("DATAFRAME")}}
+    widget._handle_client_message(msg, [])
+
+    assert widget.dataframe_html_content_status == "loaded"
+    assert widget.dataframe_html_content != ""
+
+
+def test_dataframe_tab_sets_failed_when_df_is_none() -> None:
+    thread = _make_thread(df=None)
+    widget = MultimodalWidget(thread=thread)
+
+    msg = {"action": {"type": "SELECT_MODALITY", "payload": json.dumps("DATAFRAME")}}
+    widget._handle_client_message(msg, [])
+
+    assert widget.dataframe_html_content_status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# SELECT_MODALITY: DESCRIPTION tab
+# ---------------------------------------------------------------------------
+
+
+def test_description_tab_loads_text() -> None:
+    thread = _make_thread(text="initial text")
+    widget = MultimodalWidget(thread=thread)
+    # Reset to initial to simulate lazy loading scenario
+    widget.text_status = "initial"
+    widget.text = ""
+
+    thread.text.return_value = "loaded text"
+    msg = {"action": {"type": "SELECT_MODALITY", "payload": json.dumps("DESCRIPTION")}}
+    widget._handle_client_message(msg, [])
+
+    assert widget.text_status == "loaded"
+    assert widget.text == "loaded text"
+
+
+def test_description_tab_idempotent_when_already_loaded() -> None:
+    thread = _make_thread(text="some text")
+    widget = MultimodalWidget(thread=thread)
+    assert widget.text_status == "loaded"
+
+    call_count_before = thread.text.call_count
+    msg = {"action": {"type": "SELECT_MODALITY", "payload": json.dumps("DESCRIPTION")}}
+    widget._handle_client_message(msg, [])
+
+    assert thread.text.call_count == call_count_before
+
+
+# ---------------------------------------------------------------------------
+# Message handling edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_action_type_is_ignored() -> None:
+    thread = _make_thread()
+    widget = MultimodalWidget(thread=thread)
+
+    msg = {"action": {"type": "UNKNOWN_ACTION", "payload": None}}
+    # Should not raise
+    widget._handle_client_message(msg, [])
+
+
+def test_missing_action_key_is_ignored() -> None:
+    thread = _make_thread()
+    widget = MultimodalWidget(thread=thread)
+
+    widget._handle_client_message({}, [])
+    widget._handle_client_message({"action": {}}, [])
+
+
+def test_malformed_json_payload_is_ignored(sample_df: pd.DataFrame) -> None:
+    thread = _make_thread(df=sample_df)
+    widget = MultimodalWidget(thread=thread)
+
+    msg = {"action": {"type": "SELECT_MODALITY", "payload": "not valid json {"}}
+    # Should not raise — exception is caught and logged
+    widget._handle_client_message(msg, [])

--- a/uv.lock
+++ b/uv.lock
@@ -685,8 +685,14 @@ dependencies = [
 
 [package.optional-dependencies]
 examples = [
+    { name = "anywidget" },
     { name = "notebook" },
     { name = "python-dotenv" },
+    { name = "traitlets" },
+]
+jupyter = [
+    { name = "anywidget" },
+    { name = "traitlets" },
 ]
 
 [package.dev-dependencies]
@@ -707,6 +713,8 @@ requires-dist = [
     { name = "databao-context-engine", extras = ["mysql", "postgresql", "snowflake"], specifier = "~=0.3.0" },
     { name = "dbt-core", specifier = "~=1.9.0" },
     { name = "dbt-duckdb", specifier = ">=1.10.0" },
+    { name = "anywidget", marker = "extra == 'examples'", specifier = ">=0.9.0" },
+    { name = "anywidget", marker = "extra == 'jupyter'", specifier = ">=0.9.0" },
     { name = "diskcache", specifier = ">=5.6.3" },
     { name = "duckdb", specifier = ">=1.3.0" },
     { name = "edaplot-vl", specifier = "~=0.1.4" },
@@ -726,9 +734,14 @@ requires-dist = [
     { name = "snowflake-sqlalchemy", specifier = ">=1.8.2" },
     { name = "sqlalchemy", specifier = ">=2.0.45" },
     { name = "tabulate", specifier = ">=0.9.0" },
+<<<<<<< HEAD
     { name = "watchdog", specifier = ">=6.0.0" },
+=======
+    { name = "traitlets", marker = "extra == 'examples'", specifier = ">=5.0.0" },
+    { name = "traitlets", marker = "extra == 'jupyter'", specifier = ">=5.0.0" },
+>>>>>>> 18b37d9 (Guard Jupyter-specific imports so the package works without)
 ]
-provides-extras = ["examples"]
+provides-extras = ["examples", "jupyter"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -734,12 +734,9 @@ requires-dist = [
     { name = "snowflake-sqlalchemy", specifier = ">=1.8.2" },
     { name = "sqlalchemy", specifier = ">=2.0.45" },
     { name = "tabulate", specifier = ">=0.9.0" },
-<<<<<<< HEAD
-    { name = "watchdog", specifier = ">=6.0.0" },
-=======
     { name = "traitlets", marker = "extra == 'examples'", specifier = ">=5.0.0" },
     { name = "traitlets", marker = "extra == 'jupyter'", specifier = ">=5.0.0" },
->>>>>>> 18b37d9 (Guard Jupyter-specific imports so the package works without)
+    { name = "watchdog", specifier = ">=6.0.0" },
 ]
 provides-extras = ["examples", "jupyter"]
 


### PR DESCRIPTION
This PR introduces a new multimodal widget that allows users to view Vega-Lite charts, DataFrames, and text descriptions in a Jupyter environment.

## New Features

- **Update `thread.html()` method**  
  Now it generates a standalone HTML page and either opens it in the default browser or returns a Jupyter widget, depending on the environment in which Databao is running.

- **New target: Jupyter**  
  Adds a Python implementation of the Anywidget component. Introduces a new `jupyter` client target that uses the Anywidget library to enable communication between the kernel and the UI.

- **Lazy spec generation**  
  Generates chart specs lazily, only when the chart tab is opened, to improve performance.
  

https://github.com/user-attachments/assets/0edbeb40-9b68-47d1-9dba-3fc750814c6e

