### PR TITLE
Rename PyPI package from databao to databao-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![official project](https://jb.gg/badges/official.svg)](https://github.com/JetBrains#jetbrains-on-github)
-[![PyPI version](https://img.shields.io/pypi/v/databao.svg)](https://pypi.org/project/databao)
-[![Python versions](https://img.shields.io/pypi/pyversions/databao.svg)](https://pypi.org/project/databao/)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/JetBrains/databao/blob/main/LICENSE)
+[![PyPI version](https://img.shields.io/pypi/v/databao-agent.svg)](https://pypi.org/project/databao-agent)
+[![Python versions](https://img.shields.io/pypi/pyversions/databao-agent.svg)](https://pypi.org/project/databao-agent/)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/JetBrains/databao-agent/blob/main/LICENSE.md)
 [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1zYAlVbuOfIA3Ux5LVahM2eBU7wJplO48?usp=sharing)
 
 <h1 align="center">Databao Agent</h1>
@@ -59,7 +59,7 @@ Get back **tables, charts, and explanations** — no SQL or code needed.
 ## Installation
 
 ```bash
-pip install databao
+pip install databao-agent
 ```
 
 ## Supported data sources

--- a/examples/web_shop_orders/web_shop_orders_databao_preparation_demo.ipynb
+++ b/examples/web_shop_orders/web_shop_orders_databao_preparation_demo.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "source": [
     "# Install Databao and other packages (safe to re-run)\n",
-    "!pip install -q duckdb databao matplotlib pandas\n"
+    "!pip install -q duckdb databao-agent matplotlib pandas\n"
    ],
    "outputs": [],
    "execution_count": null

--- a/examples/web_shop_orders/web_shop_orders_databao_reporting_demo.ipynb
+++ b/examples/web_shop_orders/web_shop_orders_databao_reporting_demo.ipynb
@@ -42,7 +42,7 @@
    "outputs": [],
    "source": [
     "# Install Databao and other packages (safe to rerun)\n",
-    "!pip install -q duckdb databao matplotlib pandas"
+    "!pip install -q duckdb databao-agent matplotlib pandas"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "databao"
-description = "databao: NL queries for data"
+name = "databao-agent"
+description = "databao-agent: NL queries for data"
 dynamic = ["version"]  # Based on the git tag
 requires-python = ">=3.11, <3.15"
 readme = "README.md"
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.urls]
 Homepage = "https://databao.app/"
-Source = "https://github.com/JetBrains/databao"
+Source = "https://github.com/JetBrains/databao-agent"
 
 [project.optional-dependencies]
 jupyter = [

--- a/scripts/generate_licenses.py
+++ b/scripts/generate_licenses.py
@@ -157,7 +157,7 @@ def read_python_licenses(file_path: Path) -> list[dict[str, str]]:
     """
     Read and parse Python licenses from CSV format.
 
-    Filters out the current project itself (databao) from the report since it's not
+    Filters out the current project itself (databao-agent) from the report since it's not
     a third-party dependency. The project gets installed during 'uv run --with'
     even though we only want third-party packages in the final report.
     """
@@ -167,7 +167,7 @@ def read_python_licenses(file_path: Path) -> list[dict[str, str]]:
         reader = csv.DictReader(f)
         for row in reader:
             # Filter out the project itself - only include actual third-party dependencies
-            if row["Name"].lower() == "databao":
+            if row["Name"].lower() == "databao-agent":
                 continue
 
             licenses.append(

--- a/uv.lock
+++ b/uv.lock
@@ -715,7 +715,7 @@ wheels = [
 ]
 
 [[package]]
-name = "databao"
+name = "databao-agent"
 source = { editable = "." }
 dependencies = [
     { name = "databao-context-engine", extra = ["mysql", "postgresql", "snowflake"] },


### PR DESCRIPTION
## Summary
Rename the PyPI package from `databao` to `databao-agent` to align with the repository name. This is a non-breaking change for existing users (Python import `import databao` remains unchanged).

## Changes

### Change 1: Rename PyPI package in pyproject.toml
Updated the package `name` and `description` fields.

<details>
<summary>Affected files</summary>

- `pyproject.toml`

</details>

### Change 2: Update installation instructions and badges in README
Updated `pip install` command and PyPI badge URLs to reference the new package name.

<details>
<summary>Affected files</summary>

- `README.md`

</details>

### Change 3: Update uv.lock
Lock file updated to reflect the package rename.

<details>
<summary>Affected files</summary>

- `uv.lock`

</details>

## Test Plan
- Pre-commit checks pass (`make check`)
- All non-API tests pass (`uv run pytest -v -m "not apikey"`: 101 passed, 1 xfailed)

## Notes
- After merging, a patch release tag (`v0.1.4`) should be pushed to publish the package under the new name on PyPI
- A follow-up PR will rename the Python module from `databao` to `databao_agent`, followed by a minor release