### PR TITLE
Error when opening Chart tab after calling thread.html()

### DIFF
--- a/databao/multimodal/html_viewer.py
+++ b/databao/multimodal/html_viewer.py
@@ -33,6 +33,7 @@ class MultimodalHTTPRequestHandler(BaseHTTPRequestHandler):
     thread: "Thread"
     html_bytes: bytes
     html_path: str
+    shutdown_event: threading.Event
 
     def do_GET(self) -> None:
         path = self.path.split("?", 1)[0]
@@ -179,7 +180,7 @@ class MultimodalHTTPRequestHandler(BaseHTTPRequestHandler):
                 )
         finally:
             _send_sse(event="close", data=None)
-            threading.Thread(target=self.server.shutdown).start()
+            self.shutdown_event.set()
 
     def log_message(self, format: str, *args: Any) -> None:
         return
@@ -236,22 +237,25 @@ def open_html_content(thread: "Thread") -> str:
     html = template.replace(DATA_PLACEHOLDER, f"window.__DATA__ = {data_json};")
     html_bytes = html.encode("utf-8")
 
+    shutdown_event = threading.Event()
+
     MultimodalHTTPRequestHandler.thread = thread
     MultimodalHTTPRequestHandler.html_bytes = html_bytes
     MultimodalHTTPRequestHandler.html_path = _generate_short_id()
+    MultimodalHTTPRequestHandler.shutdown_event = shutdown_event
 
     server = HTTPServer(("127.0.0.1", 0), MultimodalHTTPRequestHandler)
     port = server.server_port
     url = f"http://127.0.0.1:{port}/"
 
-    def run_server_and_cleanup() -> None:
-        server.serve_forever()
-        server.server_close()
-
-    server_thread = threading.Thread(target=run_server_and_cleanup)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
     server_thread.start()
 
     webbrowser.open(url, new=2, autoraise=True)
+
+    shutdown_event.wait()
+    server.shutdown()
+    server.server_close()
 
     return url
 

--- a/databao/multimodal/html_viewer.py
+++ b/databao/multimodal/html_viewer.py
@@ -78,6 +78,7 @@ class MultimodalHTTPRequestHandler(BaseHTTPRequestHandler):
             self.send_header("Connection", "keep-alive")
             self.end_headers()
         except Exception:
+            self.shutdown_event.set()
             return
 
         result_queue: queue.Queue[Any] = queue.Queue()


### PR DESCRIPTION
# Summary

Error when opening Chart tab after calling thread.html()

# How to Reproduce

1.  Run:

``` python
thread = agent.thread()
thread.ask("count cancelled shows by directors")
thread.html()
```

3.  Wait for the browser to open
4.  Click the **Chart** tab
5.  The chart fails to load. The terminal prints: 
``` text
RuntimeError: can't create new thread at interpreter shutdown
```

------------------------------------------------------------------------

# Root Cause

`open_html_content` starts the HTTP server in a background thread and **returns immediately**.\
As a result, the main thread in `demo.py` exits right after calling `thread.html()`.

When the main thread exits, Python begins interpreter shutdown.

However, because the http server thread was **non-daemon**, Python waits for
it to finish before fully exiting.

This creates a race condition:
-   The interpreter is mid-shutdown
-   The server thread is still alive and serving requests

When the user clicks the **Chart** tab:

1.  The SSE handler runs to completion.
2.  It attempts to stop the server.
3.  A new thread is created during interpreter shutdown.
4.  The crash occurs

------------------------------------------------------------------------

# Fix

## Old behavior

-   The request handler spawns a new thread
-   That thread calls `server.shutdown()`

###New behavior

1.  The request handler signals a `threading.Event`
2.  The main thread:
    -   Opens the browser
    -   Blocks on `shutdown_event.wait()`
    -   Keeps Python fully alive (no shutdown race)
3.  When the SSE handler finishes:
    -   It calls `shutdown_event.set()`
4.  The main thread wakes up and calls `server.shutdown()` directly
6.  The server thread is daemonized, since the main thread owns the server lifetime
