### PR TITLE
[DBA-114] Change how history is provided to visualizers

### DIFF
--- a/databao/core/thread.py
+++ b/databao/core/thread.py
@@ -98,13 +98,27 @@ class Thread:
             raise RuntimeError("_data_result is None after materialization")
         return self._data_result
 
+    def _collect_user_questions_from_cache(self) -> list[str]:
+        """Extract user question strings from the conversation history in the cache."""
+        from langchain_core.messages import HumanMessage
+
+        cache = self._agent.cache.scoped(self._cache_scope)
+        messages: list[Any] = cache.get("state", {}).get("messages", [])
+        return [str(m.content) for m in messages if isinstance(m, HumanMessage)]
+
     def _materialize_visualization(self, request: str | None, rows_limit: int | None) -> "VisualisationResult":
         """Materialize latest visualization for the given request and current data."""
         data = self._materialize_data(rows_limit)
         if self._visualization_result is None or request != self._visualization_request:
             # TODO Cache visualization results as in Executor.execute()?
             stream = self._stream_plot if self._stream_plot is not None else self._default_stream_plot
-            self._visualization_result = self._agent.visualizer.visualize(request, data, stream=stream)
+            questions = self._collect_user_questions_from_cache()
+            self._visualization_result = self._agent.visualizer.visualize(
+                request,
+                data,
+                questions=questions,
+                stream=stream,
+            )
             self._visualization_request = request
             for key, value in self._visualization_result.meta.items():
                 # We don't want to override existing metadata keys

--- a/databao/core/visualizer.py
+++ b/databao/core/visualizer.py
@@ -123,16 +123,32 @@ class Visualizer(ABC):
 
     DEFAULT_REQUEST = "I don't know what the data is about. Show me an interesting plot."
 
-    def visualize(self, request: str | None, data: ExecutionResult, *, stream: bool = False) -> VisualisationResult:
+    def visualize(
+        self,
+        request: str | None,
+        data: ExecutionResult,
+        *,
+        questions: list[str] | None = None,
+        stream: bool = False,
+    ) -> VisualisationResult:
         """Produce a visualization for the given data and optional user request.
 
         If *request* is ``None``, :attr:`DEFAULT_REQUEST` is used.  The request
         is then enriched with conversation history according to :attr:`history_mode`
         before being forwarded to :meth:`_visualize`.
+
+        Args:
+            request: Natural-language visualization request, or None for default.
+            data: The execution result containing the dataframe and metadata.
+            questions: Pre-extracted user question strings for history enrichment.
+                When provided, these are used directly instead of extracting from
+                ``data.meta``. Useful when the caller already has the conversation
+                history (e.g. from the cache).
+            stream: Whether to stream LLM output.
         """
         if request is None or request.strip() == "":
             request = self.DEFAULT_REQUEST
-        enriched = self._enrich_with_history_context(request, data)
+        enriched = self._enrich_with_history_context(request, data, questions=questions)
         return self._visualize(enriched, data, stream=stream)
 
     @abstractmethod
@@ -158,16 +174,30 @@ class Visualizer(ABC):
         """Refine a prior visualization with a natural language request."""
         pass
 
-    def _enrich_with_history_context(self, request: str, data: ExecutionResult) -> str:
+    def _enrich_with_history_context(
+        self,
+        request: str,
+        data: ExecutionResult,
+        *,
+        questions: list[str] | None = None,
+    ) -> str:
         """Prepend conversation history to the visualization request.
 
         Returns the original *request* unchanged for ``NONE``, or a new string
         with a ``User question history:`` / ``Instructions:`` structure for other modes.
+
+        Args:
+            request: The visualization request to enrich.
+            data: The execution result (used as fallback source for questions).
+            questions: Pre-extracted user question strings. When ``None``,
+                questions are extracted from ``data.meta`` via
+                :meth:`_collect_human_questions`.
         """
         if self.history_mode == HistoryMode.NONE:
             return request
 
-        questions = self._collect_human_questions(data)
+        if questions is None:
+            questions = self._collect_human_questions(data)
         if not questions:
             return request
 


### PR DESCRIPTION
Previously it was retrieved from ExecutionResult, but it contained Langchain Message-s, which were not serialiazable properly. So now we need to pass it separately, so in UI it is possible to persist ExecutionResult and get the messages from cache, not from pickled langchain messages