### PR TITLE
Register DuckDB secret alongside ATTACH for snowflake_query() support

### DIFF
--- a/databao/databases/snowflake_adapter.py
+++ b/databao/databases/snowflake_adapter.py
@@ -143,7 +143,15 @@ class SnowflakeAdapter(DatabaseAdapter):
             if auth.private_key:
                 params["private_key"] = auth.private_key
             elif auth.private_key_file:
-                params["private_key"] = Path(auth.private_key_file).read_text()
+                try:
+                    params["private_key"] = Path(auth.private_key_file).read_text()
+                except OSError as exc:
+                    raise ValueError(
+                        f"Unable to read Snowflake private key file specified in 'private_key_file': "
+                        f"{auth.private_key_file}"
+                    ) from exc
+            else:
+                raise ValueError("No private key provided.")
             if auth.private_key_file_pwd:
                 params["private_key_passphrase"] = auth.private_key_file_pwd
         elif isinstance(auth, SnowflakeSSOAuth):
@@ -153,8 +161,13 @@ class SnowflakeAdapter(DatabaseAdapter):
                 params["okta_url"] = authenticator
             else:
                 params["auth_type"] = authenticator
+        else:
+            raise ValueError("Unsupported Snowflake authentification type.")
 
-        kv = ", ".join(f"{k} '{v}'" for k, v in params.items())
+        def _escape(v: str) -> str:
+            return v.replace("'", "''")
+
+        kv = ", ".join(f"{k} '{_escape(v)}'" for k, v in params.items())
         return f'CREATE OR REPLACE SECRET "{name}" (TYPE snowflake, {kv});'
 
     @staticmethod

--- a/databao/databases/snowflake_adapter.py
+++ b/databao/databases/snowflake_adapter.py
@@ -115,36 +115,37 @@ class SnowflakeAdapter(DatabaseAdapter):
                 f"Invalid connection config type: expected SnowflakeConnectionProperties, got {type(config)}."
             )
         connection_string = cls._create_connection_string(config)
+        # Build the secret SQL before ATTACH so that preparation errors (e.g. unreadable key file)
+        # don't leave the connection in a partially-registered state.
+        secret_sql = cls._create_secret_sql(config, name)
         shared_conn.execute("INSTALL snowflake FROM community;")
         shared_conn.execute("LOAD snowflake;")
         shared_conn.execute(f"ATTACH '{connection_string}' AS \"{name}\" (TYPE snowflake, READ_ONLY);")
-        # Also create a secret under the same name so that snowflake_query('...', '{name}') works.
-        secret_sql = cls._create_secret_sql(config, name)
         shared_conn.execute(secret_sql)
 
     @staticmethod
     def _create_secret_sql(config: SnowflakeConnectionProperties, name: str) -> str:
         params: dict[str, str] = {
-            "account": config.account,
-            "user": config.user,
+            ACCOUNT_KEY: config.account,
+            USER_KEY: config.user,
         }
         if config.database:
-            params["database"] = config.database
+            params[DATABASE_KEY] = config.database
         if config.warehouse:
-            params["warehouse"] = config.warehouse
+            params[WAREHOUSE_KEY] = config.warehouse
         if config.role:
             params["role"] = config.role
 
         auth = config.auth
         if isinstance(auth, SnowflakePasswordAuth):
-            params["password"] = auth.password
+            params[PASSWORD_KEY] = auth.password
         elif isinstance(auth, SnowflakeKeyPairAuth):
-            params["auth_type"] = AUTH_TYPE_KEY_PAIR
+            params[AUTH_TYPE_KEY] = AUTH_TYPE_KEY_PAIR
             if auth.private_key:
-                params["private_key"] = auth.private_key
+                params[PRIVATE_KEY_KEY] = auth.private_key
             elif auth.private_key_file:
                 try:
-                    params["private_key"] = Path(auth.private_key_file).read_text()
+                    params[PRIVATE_KEY_KEY] = Path(auth.private_key_file).read_text()
                 except OSError as exc:
                     raise ValueError(
                         f"Unable to read Snowflake private key file specified in 'private_key_file': "
@@ -153,16 +154,16 @@ class SnowflakeAdapter(DatabaseAdapter):
             else:
                 raise ValueError("No private key provided.")
             if auth.private_key_file_pwd:
-                params["private_key_passphrase"] = auth.private_key_file_pwd
+                params[PRIVATE_KEY_PASSPHRASE_KEY] = auth.private_key_file_pwd
         elif isinstance(auth, SnowflakeSSOAuth):
             authenticator = auth.authenticator
             if SnowflakeAdapter._is_okta_url(authenticator):
-                params["auth_type"] = AUTH_TYPE_OKTA
-                params["okta_url"] = authenticator
+                params[AUTH_TYPE_KEY] = AUTH_TYPE_OKTA
+                params[OKTA_URL_KEY] = authenticator
             else:
-                params["auth_type"] = authenticator
+                params[AUTH_TYPE_KEY] = authenticator
         else:
-            raise ValueError("Unsupported Snowflake authentification type.")
+            raise ValueError("Unsupported Snowflake authentication type.")
 
         def _escape(v: str) -> str:
             return v.replace("'", "''")
@@ -184,7 +185,7 @@ class SnowflakeAdapter(DatabaseAdapter):
             return SnowflakeSSOAuth(authenticator=AUTH_TYPE_OAUTH)
         if OKTA_URL_KEY in content:
             return SnowflakeSSOAuth(authenticator=content[OKTA_URL_KEY])
-        raise ValueError("Unsupported Snowflake authentification type.")
+        raise ValueError("Unsupported Snowflake authentication type.")
 
     @staticmethod
     def _create_connection_string(config: SnowflakeConnectionProperties) -> str:
@@ -216,7 +217,7 @@ class SnowflakeAdapter(DatabaseAdapter):
             else:
                 connection_parameters[AUTH_TYPE_KEY] = authenticator
         else:
-            raise ValueError("Unsupported Snowflake authentification type.")
+            raise ValueError("Unsupported Snowflake authentication type.")
 
         return ";".join(f"{k}={v!s}" for k, v in connection_parameters.items() if v is not None)
 

--- a/databao/databases/snowflake_adapter.py
+++ b/databao/databases/snowflake_adapter.py
@@ -118,6 +118,44 @@ class SnowflakeAdapter(DatabaseAdapter):
         shared_conn.execute("INSTALL snowflake FROM community;")
         shared_conn.execute("LOAD snowflake;")
         shared_conn.execute(f"ATTACH '{connection_string}' AS \"{name}\" (TYPE snowflake, READ_ONLY);")
+        # Also create a secret under the same name so that snowflake_query('...', '{name}') works.
+        secret_sql = cls._create_secret_sql(config, name)
+        shared_conn.execute(secret_sql)
+
+    @staticmethod
+    def _create_secret_sql(config: SnowflakeConnectionProperties, name: str) -> str:
+        params: dict[str, str] = {
+            "account": config.account,
+            "user": config.user,
+        }
+        if config.database:
+            params["database"] = config.database
+        if config.warehouse:
+            params["warehouse"] = config.warehouse
+        if config.role:
+            params["role"] = config.role
+
+        auth = config.auth
+        if isinstance(auth, SnowflakePasswordAuth):
+            params["password"] = auth.password
+        elif isinstance(auth, SnowflakeKeyPairAuth):
+            params["auth_type"] = AUTH_TYPE_KEY_PAIR
+            if auth.private_key:
+                params["private_key"] = auth.private_key
+            elif auth.private_key_file:
+                params["private_key"] = Path(auth.private_key_file).read_text()
+            if auth.private_key_file_pwd:
+                params["private_key_passphrase"] = auth.private_key_file_pwd
+        elif isinstance(auth, SnowflakeSSOAuth):
+            authenticator = auth.authenticator
+            if SnowflakeAdapter._is_okta_url(authenticator):
+                params["auth_type"] = AUTH_TYPE_OKTA
+                params["okta_url"] = authenticator
+            else:
+                params["auth_type"] = authenticator
+
+        kv = ", ".join(f"{k} '{v}'" for k, v in params.items())
+        return f'CREATE OR REPLACE SECRET "{name}" (TYPE snowflake, {kv});'
 
     @staticmethod
     def _create_auth(content: dict[str, Any]) -> SnowflakePasswordAuth | SnowflakeKeyPairAuth | SnowflakeSSOAuth:

--- a/tests/test_snowflake_adapter.py
+++ b/tests/test_snowflake_adapter.py
@@ -1,0 +1,188 @@
+from pathlib import Path
+from typing import Any
+
+from databao_context_engine import (
+    SnowflakeConnectionProperties,
+    SnowflakeKeyPairAuth,
+    SnowflakePasswordAuth,
+    SnowflakeSSOAuth,
+)
+
+from databao.databases.snowflake_adapter import SnowflakeAdapter
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BASE_CONFIG: dict[str, Any] = dict(account="myaccount", user="myuser", database="mydb", warehouse="mywh")
+
+
+def _make_config(auth: Any, **kwargs: Any) -> SnowflakeConnectionProperties:
+    return SnowflakeConnectionProperties(**{**BASE_CONFIG, **kwargs}, auth=auth)
+
+
+def _parse_secret_sql(sql: str) -> dict[str, str]:
+    """Parse 'CREATE OR REPLACE SECRET "name" (TYPE snowflake, k 'v', ...)' into a dict."""
+    # Extract the key-value section between the outer parentheses
+    inner = sql[sql.index("(") + 1 : sql.rindex(")")]
+    # Drop the leading "TYPE snowflake, " prefix
+    inner = inner.split(", ", 1)[1]
+    result: dict[str, str] = {}
+    for part in inner.split(", "):
+        key, _, quoted_value = part.partition(" ")
+        result[key] = quoted_value.strip("'")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# _create_secret_sql — password auth
+# ---------------------------------------------------------------------------
+
+
+def test_secret_sql_password_auth_structure() -> None:
+    config = _make_config(SnowflakePasswordAuth(password="s3cr3t"))
+    sql = SnowflakeAdapter._create_secret_sql(config, "mydb")
+
+    assert sql.startswith('CREATE OR REPLACE SECRET "mydb" (TYPE snowflake,')
+    assert sql.endswith(");")
+
+
+def test_secret_sql_password_auth_params() -> None:
+    config = _make_config(SnowflakePasswordAuth(password="s3cr3t"))
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "mydb"))
+
+    assert params["account"] == "myaccount"
+    assert params["user"] == "myuser"
+    assert params["database"] == "mydb"
+    assert params["warehouse"] == "mywh"
+    assert params["password"] == "s3cr3t"
+    assert "auth_type" not in params
+
+
+def test_secret_sql_password_auth_no_role_by_default() -> None:
+    config = _make_config(SnowflakePasswordAuth(password="s3cr3t"))
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "mydb"))
+    assert "role" not in params
+
+
+def test_secret_sql_password_auth_includes_role_when_set() -> None:
+    config = _make_config(SnowflakePasswordAuth(password="s3cr3t"), role="ANALYST")
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "mydb"))
+    assert params["role"] == "ANALYST"
+
+
+def test_secret_sql_omits_database_when_none() -> None:
+    config = SnowflakeConnectionProperties(
+        account="acct", user="usr", database=None, warehouse="wh", auth=SnowflakePasswordAuth(password="pw")
+    )
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "s"))
+    assert "database" not in params
+
+
+def test_secret_sql_omits_warehouse_when_none() -> None:
+    config = SnowflakeConnectionProperties(
+        account="acct", user="usr", database="db", warehouse=None, auth=SnowflakePasswordAuth(password="pw")
+    )
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "s"))
+    assert "warehouse" not in params
+
+
+# ---------------------------------------------------------------------------
+# _create_secret_sql — key pair auth (inline key)
+# ---------------------------------------------------------------------------
+
+
+def test_secret_sql_key_pair_inline_key() -> None:
+    auth = SnowflakeKeyPairAuth(private_key="-----BEGIN PRIVATE KEY-----\nABC\n-----END PRIVATE KEY-----\n")
+    config = _make_config(auth)
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "mydb"))
+
+    assert params["auth_type"] == "key_pair"
+    assert "BEGIN PRIVATE KEY" in params["private_key"]
+    assert "password" not in params
+    assert "private_key_passphrase" not in params
+
+
+def test_secret_sql_key_pair_inline_key_with_passphrase() -> None:
+    auth = SnowflakeKeyPairAuth(
+        private_key="-----BEGIN ENCRYPTED PRIVATE KEY-----\nXYZ\n-----END ENCRYPTED PRIVATE KEY-----\n",
+        private_key_file_pwd="mypassphrase",
+    )
+    config = _make_config(auth)
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "mydb"))
+
+    assert params["auth_type"] == "key_pair"
+    assert params["private_key_passphrase"] == "mypassphrase"
+
+
+# ---------------------------------------------------------------------------
+# _create_secret_sql — key pair auth (file path)
+# ---------------------------------------------------------------------------
+
+
+def test_secret_sql_key_pair_file_reads_content(tmp_path: Path) -> None:
+    key_content = "-----BEGIN PRIVATE KEY-----\nFILE_KEY\n-----END PRIVATE KEY-----\n"
+    key_file = tmp_path / "rsa_key.p8"
+    key_file.write_text(key_content)
+
+    auth = SnowflakeKeyPairAuth(private_key_file=str(key_file))
+    config = _make_config(auth)
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "mydb"))
+
+    assert params["auth_type"] == "key_pair"
+    assert params["private_key"] == key_content
+
+
+def test_secret_sql_key_pair_file_with_passphrase(tmp_path: Path) -> None:
+    key_file = tmp_path / "rsa_key.p8"
+    key_file.write_text("key")
+
+    auth = SnowflakeKeyPairAuth(private_key_file=str(key_file), private_key_file_pwd="phrase")
+    config = _make_config(auth)
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "mydb"))
+
+    assert params["private_key_passphrase"] == "phrase"
+
+
+# ---------------------------------------------------------------------------
+# _create_secret_sql — SSO auth
+# ---------------------------------------------------------------------------
+
+
+def test_secret_sql_sso_externalbrowser() -> None:
+    auth = SnowflakeSSOAuth(authenticator="externalbrowser")
+    config = _make_config(auth)
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "mydb"))
+
+    assert params["auth_type"] == "externalbrowser"
+    assert "okta_url" not in params
+    assert "password" not in params
+
+
+def test_secret_sql_sso_okta_url() -> None:
+    okta_url = "https://myorg.okta.com"
+    auth = SnowflakeSSOAuth(authenticator=okta_url)
+    config = _make_config(auth)
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "mydb"))
+
+    assert params["auth_type"] == "okta"
+    assert params["okta_url"] == okta_url
+
+
+def test_secret_sql_sso_oauth() -> None:
+    auth = SnowflakeSSOAuth(authenticator="oauth")
+    config = _make_config(auth)
+    params = _parse_secret_sql(SnowflakeAdapter._create_secret_sql(config, "mydb"))
+
+    assert params["auth_type"] == "oauth"
+
+
+# ---------------------------------------------------------------------------
+# _create_secret_sql — secret name quoting
+# ---------------------------------------------------------------------------
+
+
+def test_secret_sql_name_used_correctly() -> None:
+    config = _make_config(SnowflakePasswordAuth(password="pw"))
+    sql = SnowflakeAdapter._create_secret_sql(config, "my_secret_name")
+    assert 'SECRET "my_secret_name"' in sql

--- a/tests/test_snowflake_adapter.py
+++ b/tests/test_snowflake_adapter.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any
 
+import pytest
 from databao_context_engine import (
     SnowflakeConnectionProperties,
     SnowflakeKeyPairAuth,
@@ -23,14 +24,14 @@ def _make_config(auth: Any, **kwargs: Any) -> SnowflakeConnectionProperties:
 
 def _parse_secret_sql(sql: str) -> dict[str, str]:
     """Parse 'CREATE OR REPLACE SECRET "name" (TYPE snowflake, k 'v', ...)' into a dict."""
-    # Extract the key-value section between the outer parentheses
+    import re
+
     inner = sql[sql.index("(") + 1 : sql.rindex(")")]
     # Drop the leading "TYPE snowflake, " prefix
     inner = inner.split(", ", 1)[1]
     result: dict[str, str] = {}
-    for part in inner.split(", "):
-        key, _, quoted_value = part.partition(" ")
-        result[key] = quoted_value.strip("'")
+    for m in re.finditer(r"(\w+) '((?:[^']|'')*)'", inner):
+        result[m.group(1)] = m.group(2).replace("''", "'")
     return result
 
 
@@ -186,3 +187,35 @@ def test_secret_sql_name_used_correctly() -> None:
     config = _make_config(SnowflakePasswordAuth(password="pw"))
     sql = SnowflakeAdapter._create_secret_sql(config, "my_secret_name")
     assert 'SECRET "my_secret_name"' in sql
+
+
+# ---------------------------------------------------------------------------
+# _create_secret_sql — single-quote escaping
+# ---------------------------------------------------------------------------
+
+
+def test_secret_sql_escapes_single_quotes_in_password() -> None:
+    config = _make_config(SnowflakePasswordAuth(password="my'password"))
+    sql = SnowflakeAdapter._create_secret_sql(config, "s")
+    assert "my''password" in sql
+    params = _parse_secret_sql(sql)
+    assert params["password"] == "my'password"
+
+
+# ---------------------------------------------------------------------------
+# _create_secret_sql — error handling
+# ---------------------------------------------------------------------------
+
+
+def test_secret_sql_key_pair_no_key_raises() -> None:
+    auth = SnowflakeKeyPairAuth(private_key=None, private_key_file=None)
+    config = _make_config(auth)
+    with pytest.raises(ValueError, match="No private key provided"):
+        SnowflakeAdapter._create_secret_sql(config, "s")
+
+
+def test_secret_sql_key_pair_file_not_found_raises() -> None:
+    auth = SnowflakeKeyPairAuth(private_key_file="/nonexistent/path/key.p8")
+    config = _make_config(auth)
+    with pytest.raises(ValueError, match="Unable to read Snowflake private key file"):
+        SnowflakeAdapter._create_secret_sql(config, "s")


### PR DESCRIPTION
Creates a named DuckDB secret when registering a Snowflake database so that snowflake_query('...', '<name>') can be used in addition to the attached catalog. Supports password, key-pair (inline and file), and SSO/Okta auth types.