### PR TITLE
Add dev release workflow

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,14 +1,10 @@
-name: publish-pypi
+name: publish-pypi-dev
 
 on:
-  push:
-    tags:
-      # Publish on stable version tags only, e.g., v0.1.0
-      - 'v[0-9]*.[0-9]*.[0-9]*'
-      - '!v*.dev*'
+  workflow_dispatch:
 
 jobs:
-  publish-pypi:
+  publish-dev:
     runs-on: ubuntu-latest
 
     environment:
@@ -16,10 +12,33 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Compute dev version
+        id: version
+        run: |
+          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          BASE=${LATEST#v}
+          MAJOR=$(echo $BASE | cut -d. -f1)
+          MINOR=$(echo $BASE | cut -d. -f2)
+          PATCH=$(echo $BASE | cut -d. -f3)
+          NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          N=$(git tag | grep -cE "^v${NEXT}\.dev[0-9]+$" || true)
+          TAG="v${NEXT}.dev$((N + 1))"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+      - name: Create and push dev tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.version.outputs.tag }}" \
+            -m "Dev release ${{ steps.version.outputs.tag }}"
+          git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -23,13 +23,18 @@ jobs:
         id: version
         run: |
           LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-          BASE=${LATEST#v}
+          if [ -z "$LATEST" ]; then
+            BASE="0.0.0"
+          else
+            BASE=${LATEST#v}
+          fi
           MAJOR=$(echo $BASE | cut -d. -f1)
           MINOR=$(echo $BASE | cut -d. -f2)
           PATCH=$(echo $BASE | cut -d. -f3)
           NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
           N=$(git tag | grep -cE "^v${NEXT}\.dev[0-9]+$" || true)
           TAG="v${NEXT}.dev$((N + 1))"
+          echo "Computed dev version: ${TAG}"
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Create and push dev tag


### PR DESCRIPTION
## Summary
Adds a manual workflow for publishing dev pre-releases of the Agent SDK, to support testing DCE breaking changes before a full release cycle completes.

## Changes

### Change 1: Dev release workflow (`publish-pypi-dev`)
New `workflow_dispatch` workflow that lets a developer publish a dev pre-release in one click from the GitHub Actions UI. It auto-computes the next dev version from the latest stable tag (e.g. `v0.1.3` → `v0.1.4.dev1`, `v0.1.4.dev2` on re-run), creates and pushes the git tag, then builds and publishes to PyPI. Includes the same smoke tests as the regular release.

**How to trigger:**
1. Go to **Actions → publish-pypi-dev → Run workflow**
2. Click **Run workflow** — no inputs needed
3. The workflow auto-computes the next dev version and publishes it to PyPI as a pre-release

The published version can then be installed with:
```
pip install --pre databao
```

<details>
<summary>Affected files</summary>

- `.github/workflows/publish-dev.yml`

</details>

### Change 2: Fix stable tag filter in `publish.yml`
The existing workflow matched `v*`, which would have triggered on dev tags like `v0.1.4.dev1` and caused a duplicate publish. Updated to only match stable version tags.

<details>
<summary>Affected files</summary>

- `.github/workflows/publish.yml`

</details>

## Test Plan
- Verify `publish.yml` no longer triggers on `v*.dev*` tags
- Trigger `publish-pypi-dev` manually from Actions UI and confirm it picks the correct next dev version and publishes to PyPI as a pre-release