### PR TITLE
Warn user when context is built implicitly during execution

### DIFF
--- a/databao/core/executor.py
+++ b/databao/core/executor.py
@@ -195,5 +195,9 @@ class Executor(ABC):
 
     @staticmethod
     def prepare_for_execution(domain: "Domain") -> None:
-        if domain.supports_context:
+        if domain.supports_context and not domain.is_context_built():
+            print(
+                "Context has not been built yet. Building it now — this may take a while. "
+                "To avoid this delay, call domain.build_context() before starting execution."
+            )
             domain.build_context()


### PR DESCRIPTION
## Summary
When a user calls `thread.ask()` without having built context first, the agent silently triggers `domain.build_context()` — a potentially slow operation — with no user-facing feedback. This PR adds a clear message so users know what's happening and how to avoid the delay next time.

## Changes

### Warn on implicit context build in `prepare_for_execution`
Prints a message when context is built implicitly, telling the user it may take a while and suggesting they call `domain.build_context()` upfront to avoid the delay. The message is only shown when context hasn't been built yet, so it doesn't appear on subsequent calls.

<details>
<summary>Affected files</summary>

- `databao/core/executor.py`

</details>

## Test Plan
- Call `thread.ask()` without calling `domain.build_context()` first — message should appear
- Call `domain.build_context()` explicitly, then `thread.ask()` — message should not appear