### PR TITLE
[DBA-128] Raise on context build failures and fix PostgreSQL asyncpg compatibility

### DIFF
--- a/databao/core/domain.py
+++ b/databao/core/domain.py
@@ -8,6 +8,7 @@ from databao_context_engine import (
     ConfiguredDatasource,
     ContextSearchResult,
     DatasourceId,
+    DatasourceStatus,
     DatasourceType,
 )
 from pandas import DataFrame
@@ -200,7 +201,11 @@ class _DCEProjectDomain(_Domain):
         if self.is_context_built():
             return
         self._finalize_sources()
-        self._dce_project.build_context()
+        results = self._dce_project.build_context()
+        failed = [r for r in results if r.status == DatasourceStatus.FAILED]
+        if failed:
+            messages = "\n".join(f"  - {r.datasource_id}: {r.error}" for r in failed)
+            raise RuntimeError(f"{len(failed)} datasource(s) failed to build context:\n{messages}")
 
     def search_context(self, retrieve_text: str, datasource_name: str | None = None) -> list[ContextSearchResult]:
         if not self.is_context_built():

--- a/databao/databases/postgresql_adapter.py
+++ b/databao/databases/postgresql_adapter.py
@@ -7,7 +7,6 @@ from sqlalchemy import URL, Connection, Engine, make_url
 
 from databao.databases.database_adapter import DatabaseAdapter
 from databao.databases.database_connection import DBConnection, DBConnectionConfig, DBConnectionRuntime
-from databao.databases.utils import str_dict
 
 USER_KEY = "user"
 PASSWORD_KEY = "password"
@@ -18,6 +17,30 @@ DATABASE_KEY = "database"
 MAIN_KEYS = {USER_KEY, PASSWORD_KEY, HOST_KEY, PORT_KEY, DATABASE_KEY}
 
 EXCLUDED_QUERY_KEYS = {*MAIN_KEYS}
+
+# asyncpg uses server_settings dict instead of a libpq options string.
+# These sslmode values all require SSL to be enabled.
+_SSLMODE_REQUIRE = {"require", "verify-ca", "verify-full"}
+
+
+def _parse_pg_options(options_str: str) -> dict[str, str]:
+    """Parse a libpq options string into a key/value dict for asyncpg server_settings.
+
+    Handles both '-c key=value' and plain 'key=value' tokens.
+    """
+    result: dict[str, str] = {}
+    tokens = options_str.split()
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token == "-c" and i + 1 < len(tokens):
+            i += 1
+            token = tokens[i]
+        if "=" in token:
+            k, _, v = token.partition("=")
+            result[k.strip()] = v.strip()
+        i += 1
+    return result
 
 
 class PostgreSQLAdapter(DatabaseAdapter):
@@ -59,13 +82,28 @@ class PostgreSQLAdapter(DatabaseAdapter):
         if "dbname" in content:
             content[DATABASE_KEY] = content.pop("dbname")
 
+        additional_properties: dict[str, Any] = {}
+        for k, v in content.items():
+            if k in EXCLUDED_QUERY_KEYS:
+                continue
+            if k == "options":
+                # asyncpg uses server_settings dict; libpq uses an options string
+                server_settings = _parse_pg_options(v)
+                if server_settings:
+                    additional_properties["server_settings"] = server_settings
+            elif k == "sslmode":
+                # asyncpg uses ssl=True/False; libpq uses sslmode string
+                additional_properties["ssl"] = v in _SSLMODE_REQUIRE
+            else:
+                additional_properties[k] = v
+
         return PostgresConnectionProperties(
             host=sa_url.host,
             port=sa_url.port,
             database=sa_url.database,
             user=sa_url.username,
             password=sa_url.password,
-            additional_properties={k: v for k, v in content.items() if k not in EXCLUDED_QUERY_KEYS},
+            additional_properties=additional_properties,
         )
 
     @classmethod
@@ -86,6 +124,20 @@ class PostgreSQLAdapter(DatabaseAdapter):
 
     @staticmethod
     def _create_url(config: PostgresConnectionProperties) -> str:
+        # Reconstruct libpq-style query params from asyncpg-style additional_properties.
+        query: dict[str, str] = {}
+        for k, v in config.additional_properties.items():
+            if k == "server_settings" and isinstance(v, dict):
+                # Convert server_settings dict back to libpq options string
+                options = " ".join(f"{sk}={sv}" for sk, sv in v.items())
+                if options:
+                    query["options"] = options
+            elif k == "ssl" and isinstance(v, bool):
+                # Convert ssl bool back to sslmode string
+                query["sslmode"] = "require" if v else "disable"
+            else:
+                query[k] = str(v)
+
         url = URL.create(
             drivername="postgresql",
             username=config.user,
@@ -93,6 +145,6 @@ class PostgreSQLAdapter(DatabaseAdapter):
             host=config.host,
             port=config.port,
             database=config.database,
-            query=str_dict(config.additional_properties),
+            query=query,
         )
         return url.render_as_string(hide_password=False)

--- a/databao/databases/postgresql_adapter.py
+++ b/databao/databases/postgresql_adapter.py
@@ -93,7 +93,14 @@ class PostgreSQLAdapter(DatabaseAdapter):
                     additional_properties["server_settings"] = server_settings
             elif k == "sslmode":
                 # asyncpg uses ssl=True/False; libpq uses sslmode string
-                additional_properties["ssl"] = v in _SSLMODE_REQUIRE
+                sslmode = str(v).lower()
+                if sslmode == "disable":
+                    # Explicitly disable SSL
+                    additional_properties["ssl"] = False
+                elif sslmode in _SSLMODE_REQUIRE or sslmode in {"prefer", "allow"}:
+                    # SSL modes that attempt or prefer SSL map to enabling SSL
+                    additional_properties["ssl"] = True
+                # For other/unknown sslmode values, omit "ssl" and let driver defaults apply.
             else:
                 additional_properties[k] = v
 

--- a/databao/databases/postgresql_adapter.py
+++ b/databao/databases/postgresql_adapter.py
@@ -139,9 +139,15 @@ class PostgreSQLAdapter(DatabaseAdapter):
                 options = " ".join(f"{sk}={sv}" for sk, sv in v.items())
                 if options:
                     query["options"] = options
+            elif k == "sslmode":
+                # Preserve an explicit sslmode if it was provided
+                query["sslmode"] = str(v)
             elif k == "ssl" and isinstance(v, bool):
-                # Convert ssl bool back to sslmode string
-                query["sslmode"] = "require" if v else "disable"
+                # Convert ssl bool back to sslmode string, but do not overwrite an explicit sslmode
+                if "sslmode" not in query:
+                    # Map True to "require"; map False to "prefer" instead of "disable" to avoid
+                    # collapsing all non-require modes (e.g. prefer/allow) into "disable".
+                    query["sslmode"] = "require" if v else "prefer"
             else:
                 query[k] = str(v)
 


### PR DESCRIPTION
## Summary
Context build failures were silently swallowed — `build_context()` discarded the `list[BuildDatasourceResult]` returned by the DCE, so datasource failures only appeared in `logger.info` and were never visible to the user. This PR surfaces them as exceptions and fixes the underlying PostgreSQL connection issue that was being hidden.

## Changes

### Raise RuntimeError when datasources fail to build context
`_DCEProjectDomain.build_context()` now checks the results from the DCE and raises a `RuntimeError` listing all failed datasources with their error messages.

<details>
<summary>Affected files</summary>

- `databao/core/domain.py`

</details>

### Fix PostgreSQL asyncpg compatibility for libpq connection params
The context engine uses `asyncpg` for PostgreSQL introspection, but `create_config_from_runtime()` was putting libpq-style params (`options`, `sslmode`) into `additional_properties`, which asyncpg doesn't accept as keyword arguments. This was causing a `TypeError` that was silently swallowed until now.

Fix: transform `options` → `server_settings` (dict) and `sslmode` → `ssl` (bool) when building `additional_properties`, and reconstruct the libpq-style params in `_create_url()` for DuckDB ATTACH.

<details>
<summary>Affected files</summary>

- `databao/databases/postgresql_adapter.py`

</details>

## Test Plan
- The persistent variants of `test_demo_smoke` and `test_consecutive_ask_calls` were previously passing only because context build failures were silently ignored. They now pass correctly with context building succeeding end-to-end.
- All 187 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)