### PR TITLE
Fix DBA-135 SnowflakeAdapter.create_config_from_runtime() loses region

### DIFF
--- a/databao/agent/databases/snowflake_adapter.py
+++ b/databao/agent/databases/snowflake_adapter.py
@@ -11,6 +11,7 @@ from databao_context_engine import (
     SnowflakeSSOAuth,
 )
 from databao_context_engine.pluginlib.build_plugin import AbstractConfigFile
+from snowflake.connector.network import SNOWFLAKE_HOST_SUFFIX
 from sqlalchemy import Connection, Engine, make_url
 
 from databao.agent.databases.database_adapter import DatabaseAdapter
@@ -92,8 +93,13 @@ class SnowflakeAdapter(DatabaseAdapter):
         if "dbname" in content:
             content[DATABASE_KEY] = content.pop("dbname")
 
+        host: str | None = content.pop("host", None)
+        account: str = content.get(ACCOUNT_KEY, "")
+        if host and host.endswith(SNOWFLAKE_HOST_SUFFIX):
+            account = host[: -len(SNOWFLAKE_HOST_SUFFIX)]
+
         return SnowflakeConnectionProperties(
-            account=content.get(ACCOUNT_KEY),
+            account=account,
             warehouse=content.get(WAREHOUSE_KEY),
             database=content.get(DATABASE_KEY),
             user=content.get(USER_KEY),

--- a/tests/test_snowflake_adapter.py
+++ b/tests/test_snowflake_adapter.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 from databao_context_engine import (
@@ -219,3 +220,77 @@ def test_secret_sql_key_pair_file_not_found_raises() -> None:
     config = _make_config(auth)
     with pytest.raises(ValueError, match="Unable to read Snowflake private key file"):
         SnowflakeAdapter._create_secret_sql(config, "s")
+
+
+# ---------------------------------------------------------------------------
+# create_config_from_runtime — account / region reconstruction
+# ---------------------------------------------------------------------------
+
+
+def _make_snowflake_engine(connect_args: dict[str, Any]) -> MagicMock:
+    from sqlalchemy import Engine
+
+    mock = MagicMock()
+    mock.__class__ = Engine  # type: ignore[assignment]
+    mock.dialect.name = "snowflake"
+    mock.url.render_as_string.return_value = "snowflake://user:pass@account/db"
+    mock.dialect.create_connect_args.return_value = ([], connect_args)
+    return mock
+
+
+def test_create_config_from_runtime_preserves_region_in_account() -> None:
+    engine = _make_snowflake_engine(
+        {
+            "account": "nameaccount",
+            "host": "nameaccount.eu-central-1.snowflakecomputing.com",
+            "user": "user@example.com",
+            "dbname": "MYDB",
+            "warehouse": "WH",
+            "password": "secret",
+        }
+    )
+    config = SnowflakeAdapter.create_config_from_runtime(engine)
+    assert isinstance(config, SnowflakeConnectionProperties)
+    assert config.account == "nameaccount.eu-central-1"
+
+
+def test_create_config_from_runtime_no_region_keeps_bare_account() -> None:
+    engine = _make_snowflake_engine(
+        {
+            "account": "nameaccount",
+            "host": "nameaccount.snowflakecomputing.com",
+            "user": "user",
+            "password": "secret",
+        }
+    )
+    config = SnowflakeAdapter.create_config_from_runtime(engine)
+    assert isinstance(config, SnowflakeConnectionProperties)
+    assert config.account == "nameaccount"
+
+
+def test_create_config_from_runtime_no_host_falls_back_to_account() -> None:
+    engine = _make_snowflake_engine(
+        {
+            "account": "nameaccount",
+            "user": "user",
+            "password": "secret",
+        }
+    )
+    config = SnowflakeAdapter.create_config_from_runtime(engine)
+    assert isinstance(config, SnowflakeConnectionProperties)
+    assert config.account == "nameaccount"
+
+
+def test_create_config_from_runtime_host_not_in_additional_properties() -> None:
+    engine = _make_snowflake_engine(
+        {
+            "account": "nameaccount",
+            "host": "nameaccount.eu-central-1.snowflakecomputing.com",
+            "port": "443",
+            "user": "user",
+            "password": "secret",
+        }
+    )
+    config = SnowflakeAdapter.create_config_from_runtime(engine)
+    assert isinstance(config, SnowflakeConnectionProperties)
+    assert "host" not in config.additional_properties


### PR DESCRIPTION
Snowflake-SQLAlchemy stores only the bare account name in "account" and the full host (e.g., "myaccount.eu-central-1.snowflakecomputing.com") in "host". Reconstruct the full account identifier from the host when available so that the region suffix is preserved.