### PR TITLE
Comment out implicit domain.build_context() in prepare_for_execution

### DIFF
--- a/databao/agent/core/executor.py
+++ b/databao/agent/core/executor.py
@@ -190,4 +190,4 @@ class Executor(ABC):
                 "Context has not been built yet. Building it now — this may take a while. "
                 "To avoid this delay, call domain.build_context() before starting execution."
             )
-            domain.build_context()
+        #     domain.build_context()

--- a/databao/agent/core/executor.py
+++ b/databao/agent/core/executor.py
@@ -187,7 +187,7 @@ class Executor(ABC):
     def prepare_for_execution(domain: "Domain") -> None:
         if domain.supports_context and not domain.is_context_built():
             logger.warning(
-                "Context has not been built yet. Building it now — this may take a while. "
-                "To avoid this delay, call domain.build_context() before starting execution."
+                "Context has not been built! "
+                "Some executors may benefit from it — call domain.build_context() if needed."
             )
-        #     domain.build_context()
+            # domain.build_context()


### PR DESCRIPTION
## Summary
Temporarily comments out the implicit `domain.build_context()` call in `Executor.prepare_for_execution()` to test whether executors actually require it.

## Changes

### Remove implicit build_context call
If an executor works fine without this, the implicit build can be removed entirely. If the agent fails when trying to call `search_context`, it confirms the build is required.

<details>
<summary>Affected files</summary>

- `databao/agent/core/executor.py`

</details>

## Test Plan
- Run an executor with a `PersistentDomain` without calling `build_context()` manually
- Observe whether the agent's `search_context` tool fails or succeeds
- If it fails: implicit build is needed (or must be made explicit in user code)
- If it succeeds: the implicit build can be dropped