### PR TITLE
[DBA-140] Fix BigQuery credentials_json auth in DuckDB ATTACH

### DIFF
--- a/databao/agent/databases/bigquery_adapter.py
+++ b/databao/agent/databases/bigquery_adapter.py
@@ -1,5 +1,3 @@
-import json
-import tempfile
 from typing import Any
 
 from _duckdb import DuckDBPyConnection
@@ -87,14 +85,10 @@ class BigQueryAdapter(DatabaseAdapter):
             raise ValueError(
                 f"Invalid connection config type: expected BigQueryConnectionProperties, got {type(config)}."
             )
-        if isinstance(config.auth, BigQueryServiceAccountJsonAuth):
-            credentials_json = config.auth.credentials_json
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
-                json.dump(json.loads(credentials_json) if isinstance(credentials_json, str) else credentials_json, tmp)
-            config = config.model_copy(update={"auth": BigQueryServiceAccountKeyFileAuth(credentials_file=tmp.name)})
-        connection_string = cls._create_connection_string(config)
         shared_conn.execute("INSTALL bigquery FROM community;")
         shared_conn.execute("LOAD bigquery;")
+        cls._create_secret_if_needed(shared_conn, config, name)
+        connection_string = cls._create_connection_string(config)
         shared_conn.execute(f"ATTACH '{connection_string}' AS \"{name}\" (TYPE bigquery, READ_ONLY);")
         # Workaround for a bug in the DuckDB BigQuery community extension: when ORDER BY and LIMIT
         # appear together DuckDB's optimizer generates a TopN filter that the extension's
@@ -113,18 +107,26 @@ class BigQueryAdapter(DatabaseAdapter):
         return BigQueryDefaultAuth()
 
     @staticmethod
+    def _create_secret_if_needed(conn: DuckDBPyConnection, config: BigQueryConnectionProperties, name: str) -> None:
+        auth = config.auth
+        if isinstance(auth, BigQueryServiceAccountKeyFileAuth):
+            secret_param = f"SERVICE_ACCOUNT_PATH '{auth.credentials_file}'"
+        elif isinstance(auth, BigQueryServiceAccountJsonAuth):
+            escaped = auth.credentials_json.replace("'", "''")
+            secret_param = f"SERVICE_ACCOUNT_JSON '{escaped}'"
+        else:
+            return
+        scope = f"bq://{config.project}"
+        secret_name = f"bq_secret_{name}"
+        conn.execute(f"CREATE SECRET \"{secret_name}\" (TYPE BIGQUERY, SCOPE '{scope}', {secret_param});")
+
+    @staticmethod
     def _create_connection_string(config: BigQueryConnectionProperties) -> str:
         params: dict[str, str] = {PROJECT_KEY: config.project}
         if config.dataset:
             params[DATASET_KEY] = config.dataset
         if config.location:
             params[LOCATION_KEY] = config.location
-
-        auth = config.auth
-        if isinstance(auth, BigQueryServiceAccountKeyFileAuth):
-            params[CREDENTIALS_FILE_KEY] = auth.credentials_file
-        elif isinstance(auth, BigQueryServiceAccountJsonAuth):
-            params[CREDENTIALS_JSON_KEY] = auth.credentials_json
 
         for k, v in config.additional_properties.items():
             params[k] = str(v)

--- a/databao/agent/databases/bigquery_adapter.py
+++ b/databao/agent/databases/bigquery_adapter.py
@@ -89,8 +89,9 @@ class BigQueryAdapter(DatabaseAdapter):
         shared_conn.execute("LOAD bigquery;")
         cls._create_secret_if_needed(shared_conn, config, name)
         connection_string = cls._create_connection_string(config)
+        escaped_connection_string = connection_string.replace("'", "''")
         escaped_name = name.replace('"', '""')
-        shared_conn.execute(f"ATTACH '{connection_string}' AS \"{escaped_name}\" (TYPE bigquery, READ_ONLY);")
+        shared_conn.execute(f"ATTACH '{escaped_connection_string}' AS \"{escaped_name}\" (TYPE bigquery, READ_ONLY);")
         # Workaround for a bug in the DuckDB BigQuery community extension: when ORDER BY and LIMIT
         # appear together DuckDB's optimizer generates a TopN filter that the extension's
         # TransformFilter method does not handle, causing an INTERNAL error.  Disabling only the

--- a/databao/agent/databases/bigquery_adapter.py
+++ b/databao/agent/databases/bigquery_adapter.py
@@ -89,7 +89,8 @@ class BigQueryAdapter(DatabaseAdapter):
         shared_conn.execute("LOAD bigquery;")
         cls._create_secret_if_needed(shared_conn, config, name)
         connection_string = cls._create_connection_string(config)
-        shared_conn.execute(f"ATTACH '{connection_string}' AS \"{name}\" (TYPE bigquery, READ_ONLY);")
+        escaped_name = name.replace('"', '""')
+        shared_conn.execute(f"ATTACH '{connection_string}' AS \"{escaped_name}\" (TYPE bigquery, READ_ONLY);")
         # Workaround for a bug in the DuckDB BigQuery community extension: when ORDER BY and LIMIT
         # appear together DuckDB's optimizer generates a TopN filter that the extension's
         # TransformFilter method does not handle, causing an INTERNAL error.  Disabling only the
@@ -122,7 +123,7 @@ class BigQueryAdapter(DatabaseAdapter):
         params.insert(0, scope)
         secret_name_escaped = f"bq_secret_{name}".replace('"', '""')
         conn.execute(
-            f'CREATE OR REPLACE SECRET "{secret_name_escaped}" (TYPE BIGQUERY, SCOPE ?, {secret_param});',
+            f'CREATE OR REPLACE SECRET "{secret_name_escaped}" (TYPE bigquery, SCOPE ?, {secret_param});',
             params,
         )
 

--- a/databao/agent/databases/bigquery_adapter.py
+++ b/databao/agent/databases/bigquery_adapter.py
@@ -109,16 +109,22 @@ class BigQueryAdapter(DatabaseAdapter):
     @staticmethod
     def _create_secret_if_needed(conn: DuckDBPyConnection, config: BigQueryConnectionProperties, name: str) -> None:
         auth = config.auth
+        params: list[str] = []
         if isinstance(auth, BigQueryServiceAccountKeyFileAuth):
-            secret_param = f"SERVICE_ACCOUNT_PATH '{auth.credentials_file}'"
+            secret_param = "SERVICE_ACCOUNT_PATH ?"
+            params.append(auth.credentials_file)
         elif isinstance(auth, BigQueryServiceAccountJsonAuth):
-            escaped = auth.credentials_json.replace("'", "''")
-            secret_param = f"SERVICE_ACCOUNT_JSON '{escaped}'"
+            secret_param = "SERVICE_ACCOUNT_JSON ?"
+            params.append(auth.credentials_json)
         else:
             return
         scope = f"bq://{config.project}"
-        secret_name = f"bq_secret_{name}"
-        conn.execute(f"CREATE SECRET \"{secret_name}\" (TYPE BIGQUERY, SCOPE '{scope}', {secret_param});")
+        params.insert(0, scope)
+        secret_name_escaped = f"bq_secret_{name}".replace('"', '""')
+        conn.execute(
+            f'CREATE OR REPLACE SECRET "{secret_name_escaped}" (TYPE BIGQUERY, SCOPE ?, {secret_param});',
+            params,
+        )
 
     @staticmethod
     def _create_connection_string(config: BigQueryConnectionProperties) -> str:

--- a/databao/agent/databases/bigquery_adapter.py
+++ b/databao/agent/databases/bigquery_adapter.py
@@ -1,3 +1,5 @@
+import json
+import tempfile
 from typing import Any
 
 from _duckdb import DuckDBPyConnection
@@ -85,6 +87,11 @@ class BigQueryAdapter(DatabaseAdapter):
             raise ValueError(
                 f"Invalid connection config type: expected BigQueryConnectionProperties, got {type(config)}."
             )
+        if isinstance(config.auth, BigQueryServiceAccountJsonAuth):
+            credentials_json = config.auth.credentials_json
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+                json.dump(json.loads(credentials_json) if isinstance(credentials_json, str) else credentials_json, tmp)
+            config = config.model_copy(update={"auth": BigQueryServiceAccountKeyFileAuth(credentials_file=tmp.name)})
         connection_string = cls._create_connection_string(config)
         shared_conn.execute("INSTALL bigquery FROM community;")
         shared_conn.execute("LOAD bigquery;")

--- a/databao/agent/databases/bigquery_adapter.py
+++ b/databao/agent/databases/bigquery_adapter.py
@@ -137,6 +137,7 @@ class BigQueryAdapter(DatabaseAdapter):
             params[LOCATION_KEY] = config.location
 
         for k, v in config.additional_properties.items():
-            params[k] = str(v)
+            if k not in (CREDENTIALS_FILE_KEY, CREDENTIALS_JSON_KEY):
+                params[k] = str(v)
 
         return " ".join(f"{k}={v}" for k, v in params.items())

--- a/tests/test_bigquery_adapter.py
+++ b/tests/test_bigquery_adapter.py
@@ -1,5 +1,3 @@
-import json
-import os
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -234,40 +232,47 @@ class TestRegisterInDuckdb:
         mock_conn.execute.assert_any_call("ATTACH 'project=my-project' AS \"bq_ds\" (TYPE bigquery, READ_ONLY);")
         mock_conn.execute.assert_any_call("SET disabled_optimizers='top_n';")
 
-    def test_key_file_auth_includes_credentials_file(
+    def test_key_file_auth_creates_secret_and_excludes_creds_from_attach(
         self, adapter: BigQueryAdapter, key_file_config: BigQueryConnectionProperties
     ) -> None:
         mock_conn = MagicMock()
         adapter.register_in_duckdb(mock_conn, key_file_config, "bq_ds")
-        attach_call = mock_conn.execute.call_args_list[2]
-        attach_sql: str = attach_call[0][0]
-        assert "credentials_file=/path/to/key.json" in attach_sql
+        calls = [c[0][0] for c in mock_conn.execute.call_args_list]
+        # Secret should be created with SERVICE_ACCOUNT_PATH
+        secret_sql = calls[2]
+        assert "CREATE SECRET" in secret_sql
+        assert "SERVICE_ACCOUNT_PATH '/path/to/key.json'" in secret_sql
+        assert "bq://my-project" in secret_sql
+        # ATTACH should not contain credentials
+        attach_sql = calls[3]
+        assert "credentials_file" not in attach_sql
         assert "project=my-project" in attach_sql
         assert "dataset=my_dataset" in attach_sql
 
-    def test_json_auth_writes_temp_file_and_uses_credentials_file(
+    def test_json_auth_creates_secret_with_inline_json(
         self, adapter: BigQueryAdapter, json_config: BigQueryConnectionProperties
     ) -> None:
         mock_conn = MagicMock()
         adapter.register_in_duckdb(mock_conn, json_config, "bq_ds")
-        attach_call = mock_conn.execute.call_args_list[2]
-        attach_sql: str = attach_call[0][0]
+        calls = [c[0][0] for c in mock_conn.execute.call_args_list]
+        # Secret should be created with SERVICE_ACCOUNT_JSON
+        secret_sql = calls[2]
+        assert "CREATE SECRET" in secret_sql
+        assert "SERVICE_ACCOUNT_JSON" in secret_sql
+        assert "bq://my-project" in secret_sql
+        # ATTACH should not contain credentials
+        attach_sql = calls[3]
         assert "credentials_json" not in attach_sql
-        assert "credentials_file=" in attach_sql
+        assert "credentials_file" not in attach_sql
         assert "location=US" in attach_sql
-        # Extract temp file path and verify contents
-        for part in attach_sql.split():
-            if part.startswith("credentials_file="):
-                tmp_path = part.split("=", 1)[1]
-                # Strip trailing quote from ATTACH SQL
-                tmp_path = tmp_path.rstrip("'")
-                assert os.path.exists(tmp_path)
-                with open(tmp_path) as f:
-                    assert json.load(f) == {"type": "service_account"}
-                os.unlink(tmp_path)
-                break
-        else:
-            pytest.fail("credentials_file not found in ATTACH SQL")
+
+    def test_default_auth_does_not_create_secret(
+        self, adapter: BigQueryAdapter, default_config: BigQueryConnectionProperties
+    ) -> None:
+        mock_conn = MagicMock()
+        adapter.register_in_duckdb(mock_conn, default_config, "bq_ds")
+        calls = [c[0][0] for c in mock_conn.execute.call_args_list]
+        assert not any("CREATE SECRET" in c for c in calls)
 
     def test_raises_on_wrong_config_type(self, adapter: BigQueryAdapter) -> None:
         from databao_context_engine import DuckDBConnectionConfig
@@ -276,7 +281,7 @@ class TestRegisterInDuckdb:
         with pytest.raises(ValueError, match="BigQueryConnectionProperties"):
             adapter.register_in_duckdb(mock_conn, DuckDBConnectionConfig(database_path="/tmp/db.duckdb"), "name")
 
-    def test_install_load_attach_order(
+    def test_install_load_attach_order_default_auth(
         self, adapter: BigQueryAdapter, default_config: BigQueryConnectionProperties
     ) -> None:
         mock_conn = MagicMock()
@@ -287,24 +292,36 @@ class TestRegisterInDuckdb:
         assert calls[2].startswith("ATTACH")
         assert calls[3] == "SET disabled_optimizers='top_n';"
 
+    def test_install_load_secret_attach_order_with_auth(
+        self, adapter: BigQueryAdapter, key_file_config: BigQueryConnectionProperties
+    ) -> None:
+        mock_conn = MagicMock()
+        adapter.register_in_duckdb(mock_conn, key_file_config, "bq_ds")
+        calls = [c[0][0] for c in mock_conn.execute.call_args_list]
+        assert calls[0] == "INSTALL bigquery FROM community;"
+        assert calls[1] == "LOAD bigquery;"
+        assert calls[2].startswith("CREATE SECRET")
+        assert calls[3].startswith("ATTACH")
+        assert calls[4] == "SET disabled_optimizers='top_n';"
+
 
 class TestConnectionString:
     def test_default_auth_only_has_project(self, default_config: BigQueryConnectionProperties) -> None:
         result = BigQueryAdapter._create_connection_string(default_config)
         assert result == "project=my-project"
 
-    def test_key_file_auth_connection_string(self, key_file_config: BigQueryConnectionProperties) -> None:
+    def test_key_file_auth_excludes_credentials(self, key_file_config: BigQueryConnectionProperties) -> None:
         result = BigQueryAdapter._create_connection_string(key_file_config)
         assert "project=my-project" in result
         assert "dataset=my_dataset" in result
-        assert "credentials_file=/path/to/key.json" in result
+        assert "credentials_file" not in result
 
-    def test_json_auth_connection_string(self, json_config: BigQueryConnectionProperties) -> None:
+    def test_json_auth_excludes_credentials(self, json_config: BigQueryConnectionProperties) -> None:
         result = BigQueryAdapter._create_connection_string(json_config)
         assert "project=my-project" in result
         assert "dataset=my_dataset" in result
         assert "location=US" in result
-        assert 'credentials_json={"type":"service_account"}' in result
+        assert "credentials_json" not in result
 
     def test_no_dataset_when_none(self) -> None:
         config = BigQueryConnectionProperties(project="p", dataset=None)

--- a/tests/test_bigquery_adapter.py
+++ b/tests/test_bigquery_adapter.py
@@ -1,3 +1,5 @@
+import json
+import os
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -243,15 +245,29 @@ class TestRegisterInDuckdb:
         assert "project=my-project" in attach_sql
         assert "dataset=my_dataset" in attach_sql
 
-    def test_json_auth_includes_credentials_json(
+    def test_json_auth_writes_temp_file_and_uses_credentials_file(
         self, adapter: BigQueryAdapter, json_config: BigQueryConnectionProperties
     ) -> None:
         mock_conn = MagicMock()
         adapter.register_in_duckdb(mock_conn, json_config, "bq_ds")
         attach_call = mock_conn.execute.call_args_list[2]
         attach_sql: str = attach_call[0][0]
-        assert "credentials_json=" in attach_sql
+        assert "credentials_json" not in attach_sql
+        assert "credentials_file=" in attach_sql
         assert "location=US" in attach_sql
+        # Extract temp file path and verify contents
+        for part in attach_sql.split():
+            if part.startswith("credentials_file="):
+                tmp_path = part.split("=", 1)[1]
+                # Strip trailing quote from ATTACH SQL
+                tmp_path = tmp_path.rstrip("'")
+                assert os.path.exists(tmp_path)
+                with open(tmp_path) as f:
+                    assert json.load(f) == {"type": "service_account"}
+                os.unlink(tmp_path)
+                break
+        else:
+            pytest.fail("credentials_file not found in ATTACH SQL")
 
     def test_raises_on_wrong_config_type(self, adapter: BigQueryAdapter) -> None:
         from databao_context_engine import DuckDBConnectionConfig

--- a/tests/test_bigquery_adapter.py
+++ b/tests/test_bigquery_adapter.py
@@ -237,14 +237,16 @@ class TestRegisterInDuckdb:
     ) -> None:
         mock_conn = MagicMock()
         adapter.register_in_duckdb(mock_conn, key_file_config, "bq_ds")
-        calls = [c[0][0] for c in mock_conn.execute.call_args_list]
-        # Secret should be created with SERVICE_ACCOUNT_PATH
-        secret_sql = calls[2]
-        assert "CREATE SECRET" in secret_sql
-        assert "SERVICE_ACCOUNT_PATH '/path/to/key.json'" in secret_sql
-        assert "bq://my-project" in secret_sql
+        # Secret should be created with SERVICE_ACCOUNT_PATH via parameter binding
+        secret_call = mock_conn.execute.call_args_list[2]
+        secret_sql = secret_call[0][0]
+        secret_params = secret_call[0][1]
+        assert "CREATE OR REPLACE SECRET" in secret_sql
+        assert "SERVICE_ACCOUNT_PATH ?" in secret_sql
+        assert "SCOPE ?" in secret_sql
+        assert secret_params == ["bq://my-project", "/path/to/key.json"]
         # ATTACH should not contain credentials
-        attach_sql = calls[3]
+        attach_sql = mock_conn.execute.call_args_list[3][0][0]
         assert "credentials_file" not in attach_sql
         assert "project=my-project" in attach_sql
         assert "dataset=my_dataset" in attach_sql
@@ -254,14 +256,15 @@ class TestRegisterInDuckdb:
     ) -> None:
         mock_conn = MagicMock()
         adapter.register_in_duckdb(mock_conn, json_config, "bq_ds")
-        calls = [c[0][0] for c in mock_conn.execute.call_args_list]
-        # Secret should be created with SERVICE_ACCOUNT_JSON
-        secret_sql = calls[2]
-        assert "CREATE SECRET" in secret_sql
-        assert "SERVICE_ACCOUNT_JSON" in secret_sql
-        assert "bq://my-project" in secret_sql
+        # Secret should be created with SERVICE_ACCOUNT_JSON via parameter binding
+        secret_call = mock_conn.execute.call_args_list[2]
+        secret_sql = secret_call[0][0]
+        secret_params = secret_call[0][1]
+        assert "CREATE OR REPLACE SECRET" in secret_sql
+        assert "SERVICE_ACCOUNT_JSON ?" in secret_sql
+        assert secret_params == ["bq://my-project", '{"type":"service_account"}']
         # ATTACH should not contain credentials
-        attach_sql = calls[3]
+        attach_sql = mock_conn.execute.call_args_list[3][0][0]
         assert "credentials_json" not in attach_sql
         assert "credentials_file" not in attach_sql
         assert "location=US" in attach_sql
@@ -272,7 +275,7 @@ class TestRegisterInDuckdb:
         mock_conn = MagicMock()
         adapter.register_in_duckdb(mock_conn, default_config, "bq_ds")
         calls = [c[0][0] for c in mock_conn.execute.call_args_list]
-        assert not any("CREATE SECRET" in c for c in calls)
+        assert not any("CREATE OR REPLACE SECRET" in c for c in calls)
 
     def test_raises_on_wrong_config_type(self, adapter: BigQueryAdapter) -> None:
         from databao_context_engine import DuckDBConnectionConfig
@@ -300,7 +303,7 @@ class TestRegisterInDuckdb:
         calls = [c[0][0] for c in mock_conn.execute.call_args_list]
         assert calls[0] == "INSTALL bigquery FROM community;"
         assert calls[1] == "LOAD bigquery;"
-        assert calls[2].startswith("CREATE SECRET")
+        assert calls[2].startswith("CREATE OR REPLACE SECRET")
         assert calls[3].startswith("ATTACH")
         assert calls[4] == "SET disabled_optimizers='top_n';"
 


### PR DESCRIPTION
## Summary
- Fix `Unknown key in connection string: credentials_json` error when using BigQuery with service account credentials
- DuckDB's BigQuery extension does not accept any credentials in the ATTACH connection string — auth must go through `CREATE SECRET`
- Adds `_create_secret_if_needed()` that uses `SERVICE_ACCOUNT_PATH` or `SERVICE_ACCOUNT_JSON` via DuckDB's secret manager

## Changes

### Change 1: Use CREATE SECRET for BigQuery auth
Credentials are no longer passed in the ATTACH connection string. Instead, `register_in_duckdb` creates a DuckDB secret with the appropriate auth parameter before attaching.

<details>
<summary>Affected files</summary>

- `databao/agent/databases/bigquery_adapter.py`

</details>

### Change 2: Update tests
Tests now verify that `CREATE SECRET` is called with the correct parameters and that credentials are excluded from the ATTACH SQL.

<details>
<summary>Affected files</summary>

- `tests/test_bigquery_adapter.py`

</details>

## Test Plan
- All 34 BigQuery adapter unit tests pass
- `make check` passes (ruff, mypy)
- Manually verified against real BigQuery (`datalore-internal` project) with both `credentials_json` and `credentials_file` auth types

🤖 Generated with [Claude Code](https://claude.com/claude-code)