### PR TITLE
Add release make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-LATEST_STABLE := $(shell git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -1)
+LATEST_STABLE := $(or $(shell git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -1),v0.0.0)
 CURRENT_MAJOR := $(shell echo $(LATEST_STABLE) | sed 's/^v//' | cut -d. -f1)
 CURRENT_MINOR := $(shell echo $(LATEST_STABLE) | sed 's/^v//' | cut -d. -f2)
-CURRENT_BUILD := $(shell echo $(LATEST_STABLE) | sed 's/^v//' | cut -d. -f3)
+CURRENT_PATCH := $(shell echo $(LATEST_STABLE) | sed 's/^v//' | cut -d. -f3)
 
 check:
 	uv run pre-commit run --all-files
@@ -19,10 +19,13 @@ release:
 	git push origin "v$(VERSION)"
 	@echo "Tag v$(VERSION) pushed. CI will publish to PyPI."
 
-minor-release: VERSION = $(CURRENT_MAJOR).$(CURRENT_MINOR).$(shell echo $$(($(CURRENT_BUILD) + 1)))
+patch-release: VERSION = $(CURRENT_MAJOR).$(CURRENT_MINOR).$(shell echo $$(($(CURRENT_BUILD) + 1)))
+patch-release: release
+
+minor-release: VERSION = $(CURRENT_MAJOR).$(shell echo $$(($(CURRENT_MINOR) + 1))).0
 minor-release: release
 
-major-release: VERSION = $(CURRENT_MAJOR).$(shell echo $$(($(CURRENT_MINOR) + 1))).0
+major-release: VERSION = $(shell echo $$(($(CURRENT_MAJOR) + 1))).0.0
 major-release: release
 
 dev-release:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,30 @@
+LATEST_STABLE := $(shell git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$$' | head -1)
+CURRENT_MAJOR := $(shell echo $(LATEST_STABLE) | sed 's/^v//' | cut -d. -f1)
+CURRENT_MINOR := $(shell echo $(LATEST_STABLE) | sed 's/^v//' | cut -d. -f2)
+CURRENT_BUILD := $(shell echo $(LATEST_STABLE) | sed 's/^v//' | cut -d. -f3)
+
 check:
 	uv run pre-commit run --all-files
 
 test:
 	bash -c 'set -a; [ -f .env ] && source .env; set +a; uv run pytest tests/ -v'
+
+release:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Usage: make release VERSION=0.3.0"; \
+		exit 1; \
+	fi
+	@echo "Creating release v$(VERSION)..."
+	git tag -a "v$(VERSION)" -m "v$(VERSION)"
+	git push origin "v$(VERSION)"
+	@echo "Tag v$(VERSION) pushed. CI will publish to PyPI."
+
+minor-release: VERSION = $(CURRENT_MAJOR).$(CURRENT_MINOR).$(shell echo $$(($(CURRENT_BUILD) + 1)))
+minor-release: release
+
+major-release: VERSION = $(CURRENT_MAJOR).$(shell echo $$(($(CURRENT_MINOR) + 1))).0
+major-release: release
+
+dev-release:
+	gh workflow run publish-dev.yml
+	@echo "Dev release workflow triggered."

--- a/README.md
+++ b/README.md
@@ -222,6 +222,24 @@ make check
 make test
 ```
 
+### Release
+
+Versions are derived automatically from git tags via [uv-dynamic-versioning](https://github.com/ninoseki/uv-dynamic-versioning). Pushing a tag triggers CI to build and publish to PyPI.
+
+```bash
+# Bump patch version (e.g. 0.2.0 → 0.2.1)
+make minor-release
+
+# Bump minor version (e.g. 0.2.1 → 0.3.0)
+make major-release
+
+# Publish a dev build (triggers CI workflow, version auto-computed)
+make dev-release
+
+# Release an explicit version
+make release VERSION=1.0.0
+```
+
 ### Direct commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -228,9 +228,12 @@ Versions are derived automatically from git tags via [uv-dynamic-versioning](htt
 
 ```bash
 # Bump patch version (e.g. 0.2.0 → 0.2.1)
+make patch-release
+
+# Bump minor version (e.g. 0.2.0 → 0.3.0)
 make minor-release
 
-# Bump minor version (e.g. 0.2.1 → 0.3.0)
+# Bump major version (e.g. 0.2.1 → 1.0.0)
 make major-release
 
 # Publish a dev build (triggers CI workflow, version auto-computed)


### PR DESCRIPTION
## Summary
- Add `make release VERSION=X.Y.Z`, `make minor-release`, `make major-release`, and `make dev-release` targets to the Makefile
- Document the new targets in the README under a new "Release" section

## Changes

### Change 1: Release make targets
Added four targets that automate version tagging and publishing:
- `release` — creates and pushes an annotated tag for an explicit version
- `minor-release` — auto-computes next patch bump (e.g. 0.2.0 → 0.2.1)
- `major-release` — auto-computes next minor bump (e.g. 0.2.1 → 0.3.0)
- `dev-release` — triggers the `publish-dev.yml` CI workflow

<details>
<summary>Affected files</summary>

- `Makefile`

</details>

### Change 2: README documentation
Added a "Release" section under Development describing the new targets.

<details>
<summary>Affected files</summary>

- `README.md`

</details>

## Test Plan
- `make -n minor-release` prints the correct next patch version
- `make -n major-release` prints the correct next minor version
- `make -n release VERSION=1.0.0` prints the correct tag commands