### PR TITLE
Fix DuckDB secret when using Snowflake's external browser authentication

### DIFF
--- a/databao/agent/databases/snowflake_adapter.py
+++ b/databao/agent/databases/snowflake_adapter.py
@@ -238,6 +238,8 @@ class SnowflakeAdapter(DatabaseAdapter):
             if SnowflakeAdapter._is_okta_url(authenticator):
                 params[AUTH_TYPE_KEY] = AUTH_TYPE_OKTA
                 params[OKTA_URL_KEY] = authenticator
+            elif authenticator == "externalbrowser":
+                params[AUTH_TYPE_KEY] = "ext_browser"
             else:
                 params[AUTH_TYPE_KEY] = authenticator
         else:

--- a/tests/test_snowflake_adapter.py
+++ b/tests/test_snowflake_adapter.py
@@ -136,7 +136,7 @@ def test_secret_params_sso_externalbrowser() -> None:
     config = _make_config(auth)
     params = SnowflakeAdapter._create_secret_params(config)
 
-    assert params["auth_type"] == "externalbrowser"
+    assert params["auth_type"] == "ext_browser"
     assert "okta_url" not in params
     assert "password" not in params
 


### PR DESCRIPTION
## Summary
DuckDB's secret for the Snowflake externalbrowser method need to use `AUTH_TYPE 'ext_browser'`, while the connection properties from DCE use `externalbrowser` (which is what's expected by the Snowflake Python connector and SQLAlchemy)

(see https://github.com/iqea-ai/duckdb-snowflake/blob/main/docs/AUTHENTICATION.md#4-external-browser-sso-authentication)

## Test Plan
I wasn't able to test the change as I don't have access to any Snowflake instance configured to use an external browser SSO...