### PR TITLE
Add separate_executor case in API data executor type switch

### DIFF
--- a/databao/agent/api.py
+++ b/databao/agent/api.py
@@ -46,6 +46,8 @@ def agent(
         match executor_type:
             case "lighthouse":
                 data_executor = LighthouseExecutor(writer=writer)
+            case "separate_executor":
+                data_executor = SeparateExecutor(writer=writer)
             case "dbt":
                 if dbt_config is None:
                     dbt_config = DbtConfig()

--- a/databao/agent/api.py
+++ b/databao/agent/api.py
@@ -15,6 +15,7 @@ from databao.agent.executors import (
     ReactDuckDBExecutor,
 )
 from databao.agent.executors.dbt.config import DbtConfig
+from databao.agent.executors.separate.separate_executor import SeparateExecutor
 from databao.agent.visualizers.vega_chat import VegaChatVisualizer
 
 


### PR DESCRIPTION
## Summary
Add support for the `separate_executor` type in the API endpoint's executor type switch statement. This complements #252 which introduced the `SeparateExecutor` class but missed wiring it up in the API layer.

## Changes

### Add `separate_executor` case to executor type match
The `agent()` function in the API now correctly routes the `separate_executor` type to `SeparateExecutor`, making it usable via the API.

<details>
<summary>Affected files</summary>

- `databao/agent/api.py`

</details>

## Test Plan
- Verify that passing `executor_type="separate_executor"` to the API creates a `SeparateExecutor` instance
- Confirm existing executor types (`lighthouse`, `dbt`, default) still work as expected